### PR TITLE
fix: Phase 1 致命的バグ4件修正 (Issue #5 PR1)

### DIFF
--- a/.claude/hooks/stop-retrospective-reminder.sh
+++ b/.claude/hooks/stop-retrospective-reminder.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Stop hook: セッション終了タイミングで振り返りを促す（条件付き）
+#
+# 条件:
+# 1. 最終リマインドから1時間以上経過
+# 2. 直近2時間でgit commitが3件以上
+#
+# 出力: 上記を満たす場合のみ JSON で systemMessage を返す
+#       (Claude Code が systemMessage を Claude のコンテキストに渡し、振り返りを促せる)
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "$REPO_ROOT" ]; then
+    # gitリポジトリ外なら何もしない
+    exit 0
+fi
+
+STATE_FILE="$REPO_ROOT/.claude/.last-retrospective-reminder"
+NOW=$(date +%s)
+LAST=0
+if [ -f "$STATE_FILE" ]; then
+    LAST=$(cat "$STATE_FILE" 2>/dev/null || echo 0)
+fi
+ELAPSED=$((NOW - LAST))
+
+# 1時間（3600秒）以内に既にリマインド出してたらスキップ
+if [ "$ELAPSED" -lt 3600 ]; then
+    exit 0
+fi
+
+# 直近2時間のコミット数を取得
+COMMIT_COUNT=$(git -C "$REPO_ROOT" log --oneline --since="2 hours ago" 2>/dev/null | wc -l | tr -d ' ')
+
+# 3件以上ならリマインドを出力
+if [ "$COMMIT_COUNT" -ge 3 ]; then
+    mkdir -p "$(dirname "$STATE_FILE")"
+    echo "$NOW" > "$STATE_FILE"
+
+    # systemMessage を JSON で返す
+    # additionalContext で Claude に振り返りスキル呼出を促す
+    cat <<EOF
+{
+  "systemMessage": "💡 直近2時間でコミット${COMMIT_COUNT}件検出。セッション終わる前に session-retrospective スキルで学びを CLAUDE.md / Issue に反映しませんか？",
+  "hookSpecificOutput": {
+    "hookEventName": "Stop",
+    "additionalContext": "Session has been productive (${COMMIT_COUNT} recent commits). If the user is wrapping up, suggest running session-retrospective skill to extract learnings into CLAUDE.md and create follow-up Issues. Do NOT auto-run the skill — only suggest it."
+  }
+}
+EOF
+fi
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 ## User settings
 xcuserdata/
 
+## Build artifacts (xcodebuild -derivedDataPath で生成される一時生成物)
+build/
+DerivedData/
+
 ## Obj-C/Swift specific
 *.hmap
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ xcuserdata/
 build/
 DerivedData/
 
+## Claude Code hook state files
+.claude/.last-retrospective-reminder
+
 ## Obj-C/Swift specific
 *.hmap
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,15 +16,31 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Xcodeプロジェクトを開く
 open app/BubblePopGame.xcodeproj
 
-# コマンドラインビルド
-xcodebuild -project app/BubblePopGame.xcodeproj -scheme BubblePopGame -configuration Debug build
+# コマンドラインビルド（destinationは利用可能なシミュレータに合わせる）
+xcodebuild -project app/BubblePopGame.xcodeproj -scheme BubblePopGame -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build
 
-# テスト実行
-xcodebuild test -project app/BubblePopGame.xcodeproj -scheme BubblePopGame -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest'
+# テスト実行（UnitTestのみに絞ると UITest 起動失敗の影響を避けられる）
+xcodebuild test -project app/BubblePopGame.xcodeproj -scheme BubblePopGame -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:BubblePopGameTests
+
+# Release ビルド（シミュレータ向け、警告検出に有用）
+xcodebuild build -project app/BubblePopGame.xcodeproj -scheme BubblePopGame -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
 
 # クリーンビルド
 xcodebuild clean -project app/BubblePopGame.xcodeproj -scheme BubblePopGame
 ```
+
+### 利用可能シミュレータの確認
+```bash
+xcrun simctl list devices available | grep -E "iPhone|iPad"
+```
+iPhone 16 系は存在しない環境がある（iPhone 17 系 / iPad Pro が主）。Release ビルドを実機向け (`-destination 'generic/platform=iOS'`) で実行すると Provisioning Profile が必要で失敗するため、検証は基本シミュレータ向けで行うこと。
+
+### SwiftTesting のテスト結果確認
+xcodebuild の出力は冗長なので、SwiftTesting の結果は以下の grep で抽出する:
+```bash
+xcodebuild test ... 2>&1 | grep -iE "Suite.*(started|passed|failed)|Test case .* (passed|failed)"
+```
+`** TEST SUCCEEDED **` だけ見るとどのテストが走ったか分からないので、テストの実体確認には上記パターン推奨。
 
 ## アーキテクチャ
 
@@ -64,3 +80,22 @@ app/BubblePopGame/
 - パフォーマンス監視（60FPS維持）を重視
 - オブジェクトプールパターンでメモリ効率化
 - アクセシビリティ対応を忘れずに実装
+
+### MainActor 隔離
+
+- `@Observable class` で UI から呼ばれるサービスを書く場合は `@MainActor` 付与（特に `effects` などのSwiftUI状態を変更するメソッド）
+- 実装側だけ `@MainActor` を付けるとプロトコル適合で Swift 6 警告（`conformance ... crosses into main actor-isolated code`）が出るため、プロトコル側にも合わせて付与するのが本筋
+- 既存プロトコルを変えにくい場合は `Task { @MainActor in ... }` でラップする選択肢もあるが、`createPopEffect` のような UI 連動メソッドはレイテンシ的に同期呼び出しが望ましい
+
+### View レイヤ修正の検証戦略
+
+- View 内のハードコード値（`60.0` リテラル等）や `EnvironmentValues` の挙動は、ViewModel/Color変換の単体テストではカバーできない（リテラルをrevertしてもテストPASSしてしまう盲点）
+- そのため View 層修正は**手動 walk-through が必須**。PR description に「マージ前手動確認チェックリスト」を明記する
+- `simctl` には `tap` がないため、設定変更や tutorial スキップを伴う自動検証は不可。`xcrun simctl io ... screenshot` で起動確認＋クラッシュなしの確認までが自動化の上限
+- 永続化された GameSettings は SwiftData なので `UserDefaults trick`（`xcrun simctl spawn ... defaults write`）が効かない点に注意
+
+### Git運用
+
+- `main` には直接コミットしない。`feature/issue-N-pr-X-<topic>` のような名前で feature branch を切る
+- `build/` と `DerivedData/` は `.gitignore` 済み（`xcodebuild -derivedDataPath build/DerivedData` 利用時の生成物）
+- PR タイトルは `fix:` / `feat:` / `chore:` プレフィックス、本文に Test plan の手動確認チェックリストを含める

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,3 +99,17 @@ app/BubblePopGame/
 - `main` には直接コミットしない。`feature/issue-N-pr-X-<topic>` のような名前で feature branch を切る
 - `build/` と `DerivedData/` は `.gitignore` 済み（`xcodebuild -derivedDataPath build/DerivedData` 利用時の生成物）
 - PR タイトルは `fix:` / `feat:` / `chore:` プレフィックス、本文に Test plan の手動確認チェックリストを含める
+
+## セッション終了時の振り返り運用
+
+開発を進めるほどフローが洗練されていく「複利」を生む仕組み:
+
+- **`session-retrospective` skill**（グローバル）が用意されている。ユーザーが「終わり」「お疲れ」「振り返って」等を発話すると自動発動
+- **Stop hook**（`.claude/hooks/stop-retrospective-reminder.sh`、`.claude/settings.local.json` で登録）が、直近2時間でコミット3件以上 かつ 最終リマインドから1時間以上経過時に「振り返りませんか?」とリマインド
+- 振り返り skill は、セッション中の学びを以下に振り分けて反映:
+  - **プロジェクト知識** → CLAUDE.md（このファイル）に追記
+  - **未完了/別途対応事項** → GitHub Issue 化（`gh issue create`）
+  - **ユーザー嗜好** → memory に保存
+- これを継続することで、次セッションは前回の学びを最初から踏まえて動ける（同じ罠を踏まない／同じ手順を3回繰り返さない）
+
+⚠️ **stateファイル** `.claude/.last-retrospective-reminder` は `.gitignore` 対象（hookが書き込むタイムスタンプ）

--- a/app/BubblePopGame/Services/EffectService.swift
+++ b/app/BubblePopGame/Services/EffectService.swift
@@ -17,6 +17,7 @@ protocol EffectService {
     func triggerErrorFeedback()
 }
 
+@MainActor
 class EffectServiceImpl: EffectService {
     private let lightFeedback: UIImpactFeedbackGenerator
     private let mediumFeedback: UIImpactFeedbackGenerator
@@ -24,7 +25,7 @@ class EffectServiceImpl: EffectService {
     private let selectionFeedback: UISelectionFeedbackGenerator
     private let notificationFeedback: UINotificationFeedbackGenerator
     
-    var particleEffectView: ParticleEffectView?
+    var particleEffectViewModel: ParticleEffectViewModel?
     
     init() {
         self.lightFeedback = UIImpactFeedbackGenerator(style: .light)
@@ -43,7 +44,7 @@ class EffectServiceImpl: EffectService {
     
     func createPopEffect(at position: CGPoint, color: Color) {
         // パーティクルエフェクトを作成
-        particleEffectView?.addEffect(at: position, color: color)
+        particleEffectViewModel?.addEffect(at: position, color: color)
         print("🎆 Pop effect created at: \(position)")
     }
     

--- a/app/BubblePopGame/Utils/AccessibilityUtils.swift
+++ b/app/BubblePopGame/Utils/AccessibilityUtils.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUI
+import UIKit
 
 struct AccessibilityUtils {
     
@@ -128,7 +129,7 @@ struct AccessibilityUtils {
 
 extension EnvironmentValues {
     var isHighContrastEnabled: Bool {
-        false // 簡略化：常にfalseとする（実際のアプリでは適切に実装）
+        UIAccessibility.isDarkerSystemColorsEnabled
     }
     
     var isReduceMotionEnabled: Bool {

--- a/app/BubblePopGame/ViewModels/GameViewModel.swift
+++ b/app/BubblePopGame/ViewModels/GameViewModel.swift
@@ -16,7 +16,7 @@ class GameViewModel {
     var score: Int = 0
     var timeRemaining: Double = 60.0
     var bubbles: [Bubble] = []
-    var screenBounds: CGRect = CGRect(x: 0, y: 0, width: 393, height: 852) // iPhone標準サイズ
+    var screenBounds: CGRect = .zero
     var bubblesPopped: Int = 0
     var currentStreak: Int = 0
     var bestStreak: Int = 0
@@ -107,13 +107,19 @@ class GameViewModel {
         }
     }
     
-    func setupParticleEffectView(_ particleEffectView: ParticleEffectView) {
+    func setupParticleEffectViewModel(_ viewModel: ParticleEffectViewModel) {
         if let effectServiceImpl = effectService as? EffectServiceImpl {
-            effectServiceImpl.particleEffectView = particleEffectView
+            effectServiceImpl.particleEffectViewModel = viewModel
         }
     }
     
     func startGame() {
+        // screenBounds 未設定（View マウント前）の場合はバブル生成を遅延
+        // GameView.onAppear で updateScreenBounds → startGame の順に呼ばれる
+        guard screenBounds != .zero else {
+            return
+        }
+
         gameState = .playing
         score = 0
         timeRemaining = gameSettings.gameTime

--- a/app/BubblePopGame/Views/Effects/ParticleEffectView.swift
+++ b/app/BubblePopGame/Views/Effects/ParticleEffectView.swift
@@ -7,23 +7,29 @@
 
 import SwiftUI
 
-struct ParticleEffectView: View {
-    @State private var effects: [ParticleEffectData] = []
-    
-    var body: some View {
-        ZStack {
-            ForEach(effects) { effect in
-                ParticleEffect(position: effect.position, color: effect.color)
-            }
-        }
-    }
-    
+@Observable
+@MainActor
+class ParticleEffectViewModel {
+    var effects: [ParticleEffectData] = []
+
     func addEffect(at position: CGPoint, color: Color) {
         let effect = ParticleEffectData(position: position, color: color)
         effects.append(effect)
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-            effects.removeAll { $0.id == effect.id }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+            self?.effects.removeAll { $0.id == effect.id }
+        }
+    }
+}
+
+struct ParticleEffectView: View {
+    let viewModel: ParticleEffectViewModel
+
+    var body: some View {
+        ZStack {
+            ForEach(viewModel.effects) { effect in
+                ParticleEffect(position: effect.position, color: effect.color)
+            }
         }
     }
 }

--- a/app/BubblePopGame/Views/Game/GameView.swift
+++ b/app/BubblePopGame/Views/Game/GameView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct GameView: View {
     let viewModel: GameViewModel
-    @State private var particleEffectView = ParticleEffectView()
+    @State private var particleEffectViewModel = ParticleEffectViewModel()
     
     var body: some View {
         GeometryReader { geometry in
@@ -25,7 +25,7 @@ struct GameView: View {
                 .animation(.spring(response: 0.5, dampingFraction: 0.8), value: viewModel.bubbles.count)
                 
                 // Particle Effects
-                particleEffectView
+                ParticleEffectView(viewModel: particleEffectViewModel)
                 
                 // HUD
                 VStack {
@@ -131,7 +131,7 @@ struct GameView: View {
                     .padding(.horizontal)
                     
                     // プログレスバー（時間）
-                    ProgressView(value: viewModel.timeRemaining, total: 60.0)
+                    ProgressView(value: viewModel.timeRemaining, total: viewModel.gameSettings.gameTime)
                         .progressViewStyle(LinearProgressViewStyle())
                         .scaleEffect(x: 1, y: 2, anchor: .center)
                         .accentColor(viewModel.timeRemaining <= 10 ? .red : .cyan)
@@ -153,7 +153,7 @@ struct GameView: View {
             )
             .onAppear {
                 viewModel.updateScreenBounds(geometry.frame(in: .local))
-                viewModel.setupParticleEffectView(particleEffectView)
+                viewModel.setupParticleEffectViewModel(particleEffectViewModel)
                 if viewModel.gameState != .playing {
                     viewModel.startGame()
                 }

--- a/app/BubblePopGame/Views/GameOver/GameOverView.swift
+++ b/app/BubblePopGame/Views/GameOver/GameOverView.swift
@@ -99,9 +99,9 @@ struct GameOverView: View {
                         .foregroundColor(.primary)
                     
                     VStack(spacing: 8) {
-                        StatRow(label: NSLocalizedString("gameover_play_time", comment: "Play time label"), value: String(format: NSLocalizedString("seconds_format", comment: "Seconds format with decimal"), 60.0 - viewModel.timeRemaining))
-                        StatRow(label: NSLocalizedString("gameover_avg_reaction", comment: "Average reaction time label"), value: viewModel.bubblesPopped > 0 ? String(format: "%.2f" + NSLocalizedString("game_seconds_unit", comment: "Seconds unit") + "/" + NSLocalizedString("game_pieces_unit", comment: "Pieces unit"), (60.0 - viewModel.timeRemaining) / Double(viewModel.bubblesPopped)) : "N/A")
-                        StatRow(label: NSLocalizedString("gameover_bubble_density", comment: "Bubble density label"), value: String(format: "%.1f" + NSLocalizedString("game_pieces_unit", comment: "Pieces unit") + "/" + NSLocalizedString("game_seconds_unit", comment: "Seconds unit"), Double(viewModel.bubblesPopped) / max(1, 60.0 - viewModel.timeRemaining)))
+                        StatRow(label: NSLocalizedString("gameover_play_time", comment: "Play time label"), value: String(format: NSLocalizedString("seconds_format", comment: "Seconds format with decimal"), viewModel.gameSettings.gameTime - viewModel.timeRemaining))
+                        StatRow(label: NSLocalizedString("gameover_avg_reaction", comment: "Average reaction time label"), value: viewModel.bubblesPopped > 0 ? String(format: "%.2f" + NSLocalizedString("game_seconds_unit", comment: "Seconds unit") + "/" + NSLocalizedString("game_pieces_unit", comment: "Pieces unit"), (viewModel.gameSettings.gameTime - viewModel.timeRemaining) / Double(viewModel.bubblesPopped)) : "N/A")
+                        StatRow(label: NSLocalizedString("gameover_bubble_density", comment: "Bubble density label"), value: String(format: "%.1f" + NSLocalizedString("game_pieces_unit", comment: "Pieces unit") + "/" + NSLocalizedString("game_seconds_unit", comment: "Seconds unit"), Double(viewModel.bubblesPopped) / max(1, viewModel.gameSettings.gameTime - viewModel.timeRemaining)))
                     }
                 }
                 .padding()

--- a/app/BubblePopGameTests/CriticalBugFixTests.swift
+++ b/app/BubblePopGameTests/CriticalBugFixTests.swift
@@ -1,0 +1,138 @@
+//
+//  CriticalBugFixTests.swift
+//  BubblePopGameTests
+//
+//  PR1: Phase 1 致命的バグ修正の回帰テスト
+//
+
+import Testing
+import SwiftData
+import Foundation
+import SwiftUI
+import UIKit
+@testable import BubblePopGame
+
+@MainActor
+@Suite("PR1致命バグ修正")
+struct CriticalBugFixTests {
+
+    // MARK: - Helpers
+
+    static func makeContainer() throws -> ModelContainer {
+        let schema = Schema([
+            GameScore.self,
+            GameStatistics.self,
+            GameSettings.self,
+        ])
+        return try ModelContainer(
+            for: schema,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    static func makeViewModel(gameTime: Double? = nil) throws -> GameViewModel {
+        let container = try makeContainer()
+        let settings = GameSettings()
+        if let gameTime { settings.gameTime = gameTime }
+
+        return GameViewModel(
+            bubbleService: BubbleServiceImpl(screenBounds: .zero),
+            audioService: AudioServiceImpl(),
+            effectService: EffectServiceImpl(),
+            deviceService: DeviceServiceImpl(),
+            performanceService: PerformanceServiceImpl(),
+            scoreRepository: ScoreRepositoryImpl(modelContainer: container),
+            settingsRepository: SettingsRepositoryImpl(modelContainer: container),
+            statisticsRepository: StatisticsRepositoryImpl(modelContainer: container),
+            gameSettings: settings
+        )
+    }
+
+    // MARK: - 1.1 画面サイズ初期化
+
+    @Test("初期化直後の screenBounds は .zero")
+    func initialScreenBoundsIsZero() throws {
+        let vm = try Self.makeViewModel()
+        #expect(vm.screenBounds == .zero,
+                "View マウント前は .zero、onAppear で実サイズに更新される設計")
+    }
+
+    @Test("screenBounds=.zero のままで startGame してもバブル生成しない")
+    func startGameGuardsAgainstZeroBounds() throws {
+        let vm = try Self.makeViewModel()
+        vm.startGame()
+        #expect(vm.bubbles.isEmpty,
+                ".zero で startGame した場合は画面外配置防止のため生成しない")
+    }
+
+    @Test("updateScreenBounds 後に startGame するとバブル生成される")
+    func startGameGeneratesBubblesAfterScreenBoundsSet() throws {
+        let vm = try Self.makeViewModel()
+        vm.updateScreenBounds(CGRect(x: 0, y: 0, width: 400, height: 800))
+        vm.startGame()
+        #expect(!vm.bubbles.isEmpty,
+                "screenBounds 設定後 startGame でバブル生成される")
+    }
+
+    // MARK: - 1.2 時間表示
+
+    @Test("gameTime=120 で startGame すると timeRemaining も 120")
+    func startGameInitializesTimeRemainingFromSettings120() throws {
+        let vm = try Self.makeViewModel(gameTime: 120.0)
+        vm.updateScreenBounds(CGRect(x: 0, y: 0, width: 400, height: 800))
+        vm.startGame()
+        #expect(vm.timeRemaining == 120.0)
+        #expect(vm.gameSettings.gameTime == 120.0)
+    }
+
+    @Test("gameTime=30 で startGame すると timeRemaining も 30")
+    func startGameInitializesTimeRemainingFromSettings30() throws {
+        let vm = try Self.makeViewModel(gameTime: 30.0)
+        vm.updateScreenBounds(CGRect(x: 0, y: 0, width: 400, height: 800))
+        vm.startGame()
+        #expect(vm.timeRemaining == 30.0)
+    }
+
+    // MARK: - 1.3 ParticleEffectView
+
+    @Test("ParticleEffectViewModel は参照型で状態を共有する")
+    func particleEffectViewModelIsReferenceType() {
+        let vm = ParticleEffectViewModel()
+        let shared = vm
+        #expect(vm.effects.isEmpty)
+        shared.addEffect(at: CGPoint(x: 100, y: 100), color: .red)
+        #expect(vm.effects.count == 1, "参照型のため vm と shared は同じインスタンス")
+    }
+
+    @Test("EffectServiceImpl.createPopEffect は ViewModel に effect を追加する")
+    func effectServiceTriggersViewModelEffect() {
+        let service = EffectServiceImpl()
+        let viewModel = ParticleEffectViewModel()
+        service.particleEffectViewModel = viewModel
+
+        #expect(viewModel.effects.isEmpty)
+        service.createPopEffect(at: CGPoint(x: 50, y: 50), color: .blue)
+        #expect(viewModel.effects.count == 1)
+    }
+
+    // MARK: - 1.4 高コントラスト
+
+    @Test("Color.accessible(highContrast:) は通常と異なる色を返す")
+    func accessibleColorReturnsHighContrast() {
+        let original = Color.red
+        let highContrast = original.accessible(highContrast: true)
+        let normal = original.accessible(highContrast: false)
+        #expect(highContrast != normal,
+                "高コントラストフラグで色が変化する")
+    }
+
+    @Test("AccessibilityUtils.accessibleColor 高コントラストRed は Pure red")
+    func highContrastRedIsPureRed() {
+        let result = AccessibilityUtils.accessibleColor(for: .red, isHighContrast: true)
+        let uiColor = UIColor(result)
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        uiColor.getRed(&r, green: &g, blue: &b, alpha: &a)
+        #expect(r == 1.0 && g == 0.0 && b == 0.0,
+                "高コントラスト赤は Pure red (1.0, 0.0, 0.0)")
+    }
+}

--- a/plans/2026-05-17-pr1-critical-bugs.md
+++ b/plans/2026-05-17-pr1-critical-bugs.md
@@ -1,0 +1,905 @@
+# PR1: 致命的バグ修正 (Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** App Store審査前のクリティカルパスを進めるため、ゲームプレイを破壊する致命的バグ4件（画面サイズ初期化／時間表示不整合／ParticleEffectView状態更新／アクセシビリティ高コントラスト無効化）をTDDで修正する。
+
+**Architecture:** 既存のMVVM + Service層に最小限の変更で対応。最大の変更は `ParticleEffectView`（struct）から `ParticleEffectViewModel`（@Observable class）への分離。これは値型がView外から渡されたとき状態が同期されない問題の根本対処。他3件はプロパティ初期値・パラメータ参照・実装関数差し替えのみ。
+
+**Tech Stack:** Swift 5.9+ / SwiftUI / SwiftTesting / iOS 17.0+ / Xcode 16+
+
+**親プラン参照:** `plans/github-issue-federated-music.md`（Issue #5 全体計画）
+
+---
+
+## File Structure
+
+### 修正対象
+- `app/BubblePopGame/ViewModels/GameViewModel.swift` — `screenBounds` 初期値、`startGame()` ガード、`setupParticleEffectView` シグネチャ
+- `app/BubblePopGame/Views/Game/GameView.swift` — `@State` を ViewModel に置換、`ProgressView` の total 参照
+- `app/BubblePopGame/Views/GameOver/GameOverView.swift` — `60.0` ハードコード3箇所を `gameSettings.gameTime` 参照に置換
+- `app/BubblePopGame/Views/Effects/ParticleEffectView.swift` — `ParticleEffectViewModel` (@Observable class) を新規追加、`ParticleEffectView` (struct) は ViewModel を `@Bindable` で参照する形に
+- `app/BubblePopGame/Services/EffectService.swift` — `particleEffectView: ParticleEffectView?` を `particleEffectViewModel: ParticleEffectViewModel?` に変更
+- `app/BubblePopGame/Utils/AccessibilityUtils.swift` — `isHighContrastEnabled` を `UIAccessibility.isDarkerSystemColorsEnabled` 返却に修正
+
+### 新規作成
+- `app/BubblePopGameTests/CriticalBugFixTests.swift` — Task 1.1/1.2/1.4 のテスト集約（class化されるTask 1.3も含む）
+
+### 触らないファイル（PR3以降で対応）
+- `BubbleService.swift`（PR3で設定値反映）
+- `EffectServiceImpl.particleEffectView as? EffectServiceImpl` ダウンキャスト箇所 → PR3で完全除去。本PRでは型を `ParticleEffectViewModel?` に置き換えるのみで、ダウンキャスト自体は残す（最小変更原則）
+
+---
+
+## Task 0: フィーチャーブランチ作成と既存テスト状態確認
+
+**Files:** （変更なし、Git操作のみ）
+
+- [ ] **Step 1: main の最新を取得**
+
+```bash
+git fetch origin
+git status
+```
+Expected: `On branch main` / `nothing to commit, working tree clean`
+
+- [ ] **Step 2: フィーチャーブランチを作成**
+
+```bash
+git checkout -b feature/issue-5-pr1-critical-bugs
+```
+Expected: `Switched to a new branch 'feature/issue-5-pr1-critical-bugs'`
+
+- [ ] **Step 3: ベースラインのビルド確認**
+
+```bash
+xcodebuild build -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' 2>&1 | tail -20
+```
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 4: ベースラインの全テストPASS確認**
+
+```bash
+xcodebuild test -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' 2>&1 | tail -10
+```
+Expected: `** TEST SUCCEEDED **`
+
+これがベースラインで、PR1 完了後も同じ結果＋新規テスト分が PASS する状態を目指す。
+
+---
+
+## Task 1: 画面サイズ初期化問題の修正 (1.1)
+
+**Background:** `GameViewModel.swift:19` は `screenBounds` のデフォルト値を `CGRect(x: 0, y: 0, width: 393, height: 852)` というiPhone標準サイズでハードコードしている。これによりView表示前にバブル生成すると、実機のサイズと不一致になり、バブルが画面外に配置されるリスクがある。`.zero` をデフォルトにし、View側の `onAppear` で確実に更新される設計に変更する。
+
+**Files:**
+- Modify: `app/BubblePopGame/ViewModels/GameViewModel.swift:19, 116-119`
+- Test: `app/BubblePopGameTests/CriticalBugFixTests.swift` （新規作成）
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`app/BubblePopGameTests/CriticalBugFixTests.swift` を新規作成:
+
+```swift
+//
+//  CriticalBugFixTests.swift
+//  BubblePopGameTests
+//
+//  PR1: Phase 1 致命的バグ修正の回帰テスト
+//
+
+import Testing
+import SwiftData
+import Foundation
+import SwiftUI
+@testable import BubblePopGame
+
+@MainActor
+struct CriticalBugFixTests {
+
+    // MARK: - 1.1 画面サイズ初期化
+
+    @Test("GameViewModel initialized with .zero screenBounds, not iPhone 14 default")
+    func initialScreenBoundsIsZero() throws {
+        let container = try ModelContainer(
+            for: GameScore.self, GameStatistics.self, SettingsItem.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        let context = ModelContext(container)
+        let scoreRepo = ScoreRepository(context: context)
+        let settingsRepo = SettingsRepository(context: context)
+        let statsRepo = StatisticsRepository(context: context)
+
+        let vm = GameViewModel(
+            bubbleService: BubbleServiceImpl(),
+            audioService: AudioService(),
+            effectService: EffectServiceImpl(),
+            deviceService: DeviceService(),
+            performanceService: PerformanceService(),
+            scoreRepository: scoreRepo,
+            settingsRepository: settingsRepo,
+            statisticsRepository: statsRepo
+        )
+
+        #expect(vm.screenBounds == .zero,
+                "初期化直後の screenBounds は .zero であるべき。View 側 onAppear で実サイズに更新される設計")
+    }
+
+    @Test("startGame with .zero screenBounds does not generate bubbles")
+    func startGameGuardsAgainstZeroBounds() throws {
+        let container = try ModelContainer(
+            for: GameScore.self, GameStatistics.self, SettingsItem.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        let context = ModelContext(container)
+
+        let vm = GameViewModel(
+            bubbleService: BubbleServiceImpl(),
+            audioService: AudioService(),
+            effectService: EffectServiceImpl(),
+            deviceService: DeviceService(),
+            performanceService: PerformanceService(),
+            scoreRepository: ScoreRepository(context: context),
+            settingsRepository: SettingsRepository(context: context),
+            statisticsRepository: StatisticsRepository(context: context)
+        )
+        // screenBounds が .zero のまま startGame を呼ぶ
+        vm.startGame()
+
+        #expect(vm.bubbles.isEmpty,
+                "screenBounds が .zero のときは bubble を生成しない（画面外配置を防止）")
+    }
+
+    @Test("startGame after updateScreenBounds generates bubbles")
+    func startGameGeneratesBubblesAfterScreenBoundsSet() throws {
+        let container = try ModelContainer(
+            for: GameScore.self, GameStatistics.self, SettingsItem.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        let context = ModelContext(container)
+
+        let vm = GameViewModel(
+            bubbleService: BubbleServiceImpl(),
+            audioService: AudioService(),
+            effectService: EffectServiceImpl(),
+            deviceService: DeviceService(),
+            performanceService: PerformanceService(),
+            scoreRepository: ScoreRepository(context: context),
+            settingsRepository: SettingsRepository(context: context),
+            statisticsRepository: StatisticsRepository(context: context)
+        )
+        vm.updateScreenBounds(CGRect(x: 0, y: 0, width: 400, height: 800))
+        vm.startGame()
+
+        #expect(!vm.bubbles.isEmpty,
+                "screenBounds 設定後 startGame でバブルが生成される")
+    }
+}
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+xcodebuild test -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+  -only-testing:BubblePopGameTests/CriticalBugFixTests 2>&1 | tail -30
+```
+Expected: `initialScreenBoundsIsZero` が **FAIL**（現状 393x852 でデフォルト初期化されているため）
+
+- [ ] **Step 3: GameViewModel.swift の修正**
+
+`app/BubblePopGame/ViewModels/GameViewModel.swift:19` を変更:
+
+```swift
+// before
+var screenBounds: CGRect = CGRect(x: 0, y: 0, width: 393, height: 852) // iPhone標準サイズ
+
+// after
+var screenBounds: CGRect = .zero
+```
+
+`app/BubblePopGame/ViewModels/GameViewModel.swift:116-119` の `startGame()` 冒頭にガードを追加:
+
+`startGame()` メソッドの先頭（`gameState = .playing` の直前）に挿入:
+
+```swift
+func startGame() {
+    // screenBounds 未設定（View マウント前）の場合はバブル生成を遅延
+    // GameView.onAppear で updateScreenBounds → startGame の順に呼ばれる
+    guard screenBounds != .zero else {
+        return
+    }
+
+    gameState = .playing
+    score = 0
+    // ...以下既存のまま
+```
+
+- [ ] **Step 4: テスト3件がPASSすることを確認**
+
+```bash
+xcodebuild test -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+  -only-testing:BubblePopGameTests/CriticalBugFixTests 2>&1 | tail -10
+```
+Expected: 3件 PASS
+
+- [ ] **Step 5: 全テストが影響を受けていないことを確認**
+
+```bash
+xcodebuild test -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' 2>&1 | tail -10
+```
+Expected: `** TEST SUCCEEDED **`（既存テストもPASS）
+
+⚠️ もし `SimpleGameViewModelTests` などが「screenBounds がデフォルトで非ゼロ」を前提にしていた場合は、テスト側を修正する（先に `vm.updateScreenBounds(...)` を呼ぶ）。テスト側修正もこのStepに含む。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add app/BubblePopGame/ViewModels/GameViewModel.swift \
+        app/BubblePopGameTests/CriticalBugFixTests.swift
+git commit -m "$(cat <<'EOF'
+fix(GameViewModel): screenBounds初期値を.zeroにし、startGameでガード
+
+iPhone標準サイズのハードコード値（393x852）でデフォルト初期化されていたため、
+実機サイズと不一致になりバブルが画面外配置されるリスクがあった。
+.zeroをデフォルトにし、View側onAppearで実サイズ更新される設計を明確化。
+
+- screenBounds初期値: CGRect(393x852) → .zero
+- startGame()先頭で .zero ガード追加
+- CriticalBugFixTests に回帰テスト3件追加
+
+refs #5 Phase 1 (1.1)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: 時間表示不整合の修正 (1.2)
+
+**Background:** `GameView.swift:134` の `ProgressView(value: viewModel.timeRemaining, total: 60.0)` は60秒固定。設定で gameTime=120s にしてもプログレスバーは60s基準で動くため、即座に満タンに見える。`GameOverView.swift:102-104` も同じく `60.0 - viewModel.timeRemaining` で経過時間を計算しているが、これは120sプレイ後 `-60.0` のような不正値になる。全てを `viewModel.gameSettings.gameTime` 参照に置き換える。
+
+**Files:**
+- Modify: `app/BubblePopGame/Views/Game/GameView.swift:134`
+- Modify: `app/BubblePopGame/Views/GameOver/GameOverView.swift:102-104`
+- Test: `app/BubblePopGameTests/CriticalBugFixTests.swift`（追記）
+
+- [ ] **Step 1: テストを追記**
+
+`CriticalBugFixTests.swift` の struct 内に追加:
+
+```swift
+    // MARK: - 1.2 時間表示
+
+    @Test("gameTime=120 では timeRemaining 初期値も 120")
+    func startGameInitializesTimeRemainingFromSettings() throws {
+        let container = try ModelContainer(
+            for: GameScore.self, GameStatistics.self, SettingsItem.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        let context = ModelContext(container)
+        let settings = GameSettings()
+        settings.gameTime = 120.0
+
+        let vm = GameViewModel(
+            bubbleService: BubbleServiceImpl(),
+            audioService: AudioService(),
+            effectService: EffectServiceImpl(),
+            deviceService: DeviceService(),
+            performanceService: PerformanceService(),
+            scoreRepository: ScoreRepository(context: context),
+            settingsRepository: SettingsRepository(context: context),
+            statisticsRepository: StatisticsRepository(context: context),
+            gameSettings: settings
+        )
+        vm.updateScreenBounds(CGRect(x: 0, y: 0, width: 400, height: 800))
+        vm.startGame()
+
+        #expect(vm.timeRemaining == 120.0,
+                "startGame後の timeRemaining は gameSettings.gameTime を反映する")
+        #expect(vm.gameSettings.gameTime == 120.0)
+    }
+
+    @Test("gameTime=30 でも正しく初期化される")
+    func startGameWithShortTime() throws {
+        let container = try ModelContainer(
+            for: GameScore.self, GameStatistics.self, SettingsItem.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        let context = ModelContext(container)
+        let settings = GameSettings()
+        settings.gameTime = 30.0
+
+        let vm = GameViewModel(
+            bubbleService: BubbleServiceImpl(),
+            audioService: AudioService(),
+            effectService: EffectServiceImpl(),
+            deviceService: DeviceService(),
+            performanceService: PerformanceService(),
+            scoreRepository: ScoreRepository(context: context),
+            settingsRepository: SettingsRepository(context: context),
+            statisticsRepository: StatisticsRepository(context: context),
+            gameSettings: settings
+        )
+        vm.updateScreenBounds(CGRect(x: 0, y: 0, width: 400, height: 800))
+        vm.startGame()
+
+        #expect(vm.timeRemaining == 30.0)
+    }
+```
+
+- [ ] **Step 2: テストを実行して既存ロジック確認**
+
+```bash
+xcodebuild test -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+  -only-testing:BubblePopGameTests/CriticalBugFixTests/startGameInitializesTimeRemainingFromSettings 2>&1 | tail -10
+```
+Expected: PASS（このテストは GameView/GameOverView ではなく ViewModel 内のロジック検証なので、Task 1 修正後にすでにPASSする見込み。ViewModelは `timeRemaining = gameSettings.gameTime` の実装が既にある）
+
+Viewは目視検証になるため、Step 3 以降はView修正を主体とする。
+
+- [ ] **Step 3: GameView.swift:134 の修正**
+
+`app/BubblePopGame/Views/Game/GameView.swift:134`:
+
+```swift
+// before
+ProgressView(value: viewModel.timeRemaining, total: 60.0)
+
+// after
+ProgressView(value: viewModel.timeRemaining, total: viewModel.gameSettings.gameTime)
+```
+
+- [ ] **Step 4: GameOverView.swift:102-104 の修正**
+
+3箇所すべての `60.0 - viewModel.timeRemaining` を `viewModel.gameSettings.gameTime - viewModel.timeRemaining` に変更。`max(1, 60.0 - ...)` も同様に置換。
+
+`app/BubblePopGame/Views/GameOver/GameOverView.swift:102-104` を以下に書き換える:
+
+```swift
+StatRow(label: NSLocalizedString("gameover_play_time", comment: "Play time label"),
+        value: String(format: NSLocalizedString("seconds_format", comment: "Seconds format with decimal"),
+                      viewModel.gameSettings.gameTime - viewModel.timeRemaining))
+StatRow(label: NSLocalizedString("gameover_avg_reaction", comment: "Average reaction time label"),
+        value: viewModel.bubblesPopped > 0
+            ? String(format: "%.2f" + NSLocalizedString("game_seconds_unit", comment: "Seconds unit") + "/" + NSLocalizedString("game_pieces_unit", comment: "Pieces unit"),
+                     (viewModel.gameSettings.gameTime - viewModel.timeRemaining) / Double(viewModel.bubblesPopped))
+            : "N/A")
+StatRow(label: NSLocalizedString("gameover_bubble_density", comment: "Bubble density label"),
+        value: String(format: "%.1f" + NSLocalizedString("game_pieces_unit", comment: "Pieces unit") + "/" + NSLocalizedString("game_seconds_unit", comment: "Seconds unit"),
+                      Double(viewModel.bubblesPopped) / max(1, viewModel.gameSettings.gameTime - viewModel.timeRemaining)))
+```
+
+- [ ] **Step 5: ビルドと全テストPASSを確認**
+
+```bash
+xcodebuild test -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' 2>&1 | tail -10
+```
+Expected: `** TEST SUCCEEDED **`
+
+- [ ] **Step 6: シミュレータで目視確認**
+
+`Skill: ios-simulator-app-verification` を使用。手順:
+1. 設定で gameTime=120s に変更
+2. ゲーム開始
+3. プログレスバーが 120s 起点で減ることを確認（スクショ記録）
+4. ゲーム終了後 GameOver 画面で「プレイ時間」が正しい経過秒数を示すことを確認
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add app/BubblePopGame/Views/Game/GameView.swift \
+        app/BubblePopGame/Views/GameOver/GameOverView.swift \
+        app/BubblePopGameTests/CriticalBugFixTests.swift
+git commit -m "$(cat <<'EOF'
+fix(GameView/GameOverView): 60秒ハードコードを gameSettings.gameTime に置換
+
+ProgressView の total と GameOver の経過時間計算が 60.0 リテラル固定で、
+gameTime=120s 設定時にバーが満タン固定、経過時間が負値になっていた。
+
+- GameView.swift:134 ProgressView total を gameSettings.gameTime 参照に
+- GameOverView.swift:102-104 経過時間/平均反応時間/バブル密度の3箇所を
+  gameSettings.gameTime - timeRemaining に置換
+
+refs #5 Phase 1 (1.2)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: ParticleEffectView 状態更新問題の修正 (1.3)
+
+**Background:** 現在の `ParticleEffectView` は `struct` で `@State private var effects: [ParticleEffectData]` を持つ。`GameView` で `@State private var particleEffectView = ParticleEffectView()` してインスタンスを生成し、`onAppear` で `viewModel.setupParticleEffectView(particleEffectView)` で渡している。しかしSwiftUI の struct は値型で、`EffectServiceImpl` が保持する `particleEffectView` プロパティは値コピーとなる。`EffectServiceImpl.createPopEffect` が `particleEffectView?.addEffect(...)` を呼んでも、その変更は GameView 側で表示している `particleEffectView` には反映されない。これがパーティクル演出が見えない真の原因。
+
+**解決策:** `@Observable class ParticleEffectViewModel` を分離。状態（effects配列）は ViewModel に持たせ、`ParticleEffectView` (struct) は `let viewModel: ParticleEffectViewModel` を参照する。Service側も `ParticleEffectViewModel?` を保持。GameView は `@State private var particleEffectViewModel = ParticleEffectViewModel()` で参照を共有。
+
+**Files:**
+- Modify: `app/BubblePopGame/Views/Effects/ParticleEffectView.swift`
+- Modify: `app/BubblePopGame/Services/EffectService.swift:27, 46`
+- Modify: `app/BubblePopGame/ViewModels/GameViewModel.swift:110-114`
+- Modify: `app/BubblePopGame/Views/Game/GameView.swift:12, 156`
+
+- [ ] **Step 1: テストを追記**
+
+`CriticalBugFixTests.swift` に追加:
+
+```swift
+    // MARK: - 1.3 ParticleEffectView
+
+    @Test("ParticleEffectViewModel が参照型で、addEffect が状態を共有する")
+    func particleEffectViewModelIsReferenceType() {
+        let vm = ParticleEffectViewModel()
+        let shared = vm
+
+        #expect(vm.effects.isEmpty)
+        shared.addEffect(at: CGPoint(x: 100, y: 100), color: .red)
+
+        #expect(vm.effects.count == 1, "参照型のためsharedとvmは同じインスタンス")
+    }
+
+    @Test("EffectServiceImpl.createPopEffect は ViewModel に effect を追加する")
+    func effectServiceTriggersViewModelEffect() {
+        let service = EffectServiceImpl()
+        let viewModel = ParticleEffectViewModel()
+        service.particleEffectViewModel = viewModel
+
+        #expect(viewModel.effects.isEmpty)
+        service.createPopEffect(at: CGPoint(x: 50, y: 50), color: .blue)
+
+        #expect(viewModel.effects.count == 1)
+    }
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+```bash
+xcodebuild test -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+  -only-testing:BubblePopGameTests/CriticalBugFixTests/particleEffectViewModelIsReferenceType \
+  -only-testing:BubblePopGameTests/CriticalBugFixTests/effectServiceTriggersViewModelEffect 2>&1 | tail -30
+```
+Expected: コンパイルエラー `Cannot find 'ParticleEffectViewModel' in scope` または `Value of type 'EffectServiceImpl' has no member 'particleEffectViewModel'`
+
+- [ ] **Step 3: ParticleEffectView.swift を全面書き換え**
+
+`app/BubblePopGame/Views/Effects/ParticleEffectView.swift` を以下で完全に置き換え:
+
+```swift
+//
+//  ParticleEffectView.swift
+//  BubblePopGame
+//
+//  Created on 2025/08/04
+//
+
+import SwiftUI
+
+@Observable
+@MainActor
+class ParticleEffectViewModel {
+    var effects: [ParticleEffectData] = []
+
+    func addEffect(at position: CGPoint, color: Color) {
+        let effect = ParticleEffectData(position: position, color: color)
+        effects.append(effect)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+            self?.effects.removeAll { $0.id == effect.id }
+        }
+    }
+}
+
+struct ParticleEffectView: View {
+    let viewModel: ParticleEffectViewModel
+
+    var body: some View {
+        ZStack {
+            ForEach(viewModel.effects) { effect in
+                ParticleEffect(position: effect.position, color: effect.color)
+            }
+        }
+    }
+}
+```
+
+⚠️ **互換性メモ:** `ParticleEffectData` の定義は別ファイルにあると想定。もし `ParticleEffectView.swift` 内に定義があった場合はそのまま残す。実装エージェントは Read で再確認すること。
+
+- [ ] **Step 4: EffectService.swift の修正**
+
+`app/BubblePopGame/Services/EffectService.swift:27` の型を変更:
+
+```swift
+// before
+var particleEffectView: ParticleEffectView?
+
+// after
+var particleEffectViewModel: ParticleEffectViewModel?
+```
+
+`app/BubblePopGame/Services/EffectService.swift:46`:
+
+```swift
+// before
+particleEffectView?.addEffect(at: position, color: color)
+
+// after
+particleEffectViewModel?.addEffect(at: position, color: color)
+```
+
+- [ ] **Step 5: GameViewModel.swift の修正**
+
+`app/BubblePopGame/ViewModels/GameViewModel.swift:110-114` を変更:
+
+```swift
+// before
+func setupParticleEffectView(_ particleEffectView: ParticleEffectView) {
+    if let effectServiceImpl = effectService as? EffectServiceImpl {
+        effectServiceImpl.particleEffectView = particleEffectView
+    }
+}
+
+// after
+func setupParticleEffectViewModel(_ viewModel: ParticleEffectViewModel) {
+    if let effectServiceImpl = effectService as? EffectServiceImpl {
+        effectServiceImpl.particleEffectViewModel = viewModel
+    }
+}
+```
+
+⚠️ ダウンキャスト `effectService as? EffectServiceImpl` は PR3 で除去予定。本PRでは残す。
+
+- [ ] **Step 6: GameView.swift の修正**
+
+`app/BubblePopGame/Views/Game/GameView.swift:12` を変更:
+
+```swift
+// before
+@State private var particleEffectView = ParticleEffectView()
+
+// after
+@State private var particleEffectViewModel = ParticleEffectViewModel()
+```
+
+`app/BubblePopGame/Views/Game/GameView.swift:28` の表示を変更:
+
+```swift
+// before
+particleEffectView
+
+// after
+ParticleEffectView(viewModel: particleEffectViewModel)
+```
+
+`app/BubblePopGame/Views/Game/GameView.swift:156` の onAppear を変更:
+
+```swift
+// before
+viewModel.setupParticleEffectView(particleEffectView)
+
+// after
+viewModel.setupParticleEffectViewModel(particleEffectViewModel)
+```
+
+- [ ] **Step 7: ビルドを通す**
+
+```bash
+xcodebuild build -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' 2>&1 | tail -20
+```
+Expected: `** BUILD SUCCEEDED **`
+
+エラーが出る場合は、他に `ParticleEffectView()` をinstance化している箇所がないか grep で確認:
+
+```bash
+grep -rn "ParticleEffectView()" app/BubblePopGame --include="*.swift"
+grep -rn "setupParticleEffectView\b" app/BubblePopGame --include="*.swift"
+```
+
+- [ ] **Step 8: テスト2件がPASSすることを確認**
+
+```bash
+xcodebuild test -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+  -only-testing:BubblePopGameTests/CriticalBugFixTests 2>&1 | tail -10
+```
+Expected: 全テストPASS
+
+- [ ] **Step 9: 全テストが影響を受けていないことを確認**
+
+```bash
+xcodebuild test -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' 2>&1 | tail -10
+```
+Expected: `** TEST SUCCEEDED **`
+
+- [ ] **Step 10: シミュレータで目視確認**
+
+`Skill: ios-simulator-app-verification` を使用。手順:
+1. ゲーム開始
+2. バブルを何回かタップ
+3. パーティクル演出（小さな円が広がる）が表示されることを確認
+4. 1.5秒後に消えることを確認
+5. スクショを撮影
+
+- [ ] **Step 11: コミット**
+
+```bash
+git add app/BubblePopGame/Views/Effects/ParticleEffectView.swift \
+        app/BubblePopGame/Services/EffectService.swift \
+        app/BubblePopGame/ViewModels/GameViewModel.swift \
+        app/BubblePopGame/Views/Game/GameView.swift \
+        app/BubblePopGameTests/CriticalBugFixTests.swift
+git commit -m "$(cat <<'EOF'
+fix(ParticleEffect): struct→@Observable class分離で状態更新を反映
+
+ParticleEffectView が struct のため、Service 側に渡した値コピーへの
+addEffect は GameView 表示インスタンスに反映されなかった。
+@Observable class ParticleEffectViewModel に状態を分離し、参照型で共有。
+
+- ParticleEffectViewModel (@Observable class) 新設
+- ParticleEffectView は viewModel を参照する struct に変更
+- EffectServiceImpl.particleEffectView → particleEffectViewModel
+- GameViewModel.setupParticleEffectView → setupParticleEffectViewModel
+- GameView の @State も ViewModel に変更
+- as? EffectServiceImpl ダウンキャストは PR3 で除去予定
+
+refs #5 Phase 1 (1.3)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: アクセシビリティ高コントラスト有効化 (1.4)
+
+**Background:** `AccessibilityUtils.swift:131` の `isHighContrastEnabled` が常に `false` を返す簡略化実装になっている。視覚支援を必要とするユーザに高コントラスト色が適用されない。`UIAccessibility.isDarkerSystemColorsEnabled` を返すように修正。
+
+**Files:**
+- Modify: `app/BubblePopGame/Utils/AccessibilityUtils.swift:130-132`
+- Test: `app/BubblePopGameTests/CriticalBugFixTests.swift`（追記）
+
+- [ ] **Step 1: テストを追記**
+
+`CriticalBugFixTests.swift` に追加:
+
+```swift
+    // MARK: - 1.4 高コントラスト
+
+    @Test("Color.accessible(highContrast: true) は高コントラスト色を返す")
+    func accessibleColorReturnsHighContrast() {
+        let original = Color.red
+        let highContrast = original.accessible(highContrast: true)
+        let normal = original.accessible(highContrast: false)
+
+        #expect(highContrast != normal,
+                "高コントラストフラグで色が変化する")
+    }
+
+    @Test("AccessibilityUtils.accessibleColor 高コントラストRed は Pure red")
+    func highContrastRedIsPureRed() {
+        let result = AccessibilityUtils.accessibleColor(for: .red, isHighContrast: true)
+        // Pure red の RGB を確認するため UIColor 経由で比較
+        let uiColor = UIColor(result)
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        uiColor.getRed(&r, green: &g, blue: &b, alpha: &a)
+        #expect(r == 1.0 && g == 0.0 && b == 0.0,
+                "高コントラスト赤は Pure red (1.0, 0.0, 0.0)")
+    }
+```
+
+⚠️ `isHighContrastEnabled` 自体は SwiftUI Environment 経由なのでテストが難しい。代わりに「色変換ロジック」と「Environment が `UIAccessibility.isDarkerSystemColorsEnabled` を返すという宣言」を担保する単体テストとする。
+
+- [ ] **Step 2: AccessibilityUtils.swift:130-132 の修正**
+
+`app/BubblePopGame/Utils/AccessibilityUtils.swift:127-137` の `EnvironmentValues` extension を変更:
+
+```swift
+// before
+extension EnvironmentValues {
+    var isHighContrastEnabled: Bool {
+        false // 簡略化：常にfalseとする（実際のアプリでは適切に実装）
+    }
+
+    var isReduceMotionEnabled: Bool {
+        self.accessibilityReduceMotion
+    }
+}
+
+// after
+extension EnvironmentValues {
+    var isHighContrastEnabled: Bool {
+        UIAccessibility.isDarkerSystemColorsEnabled
+    }
+
+    var isReduceMotionEnabled: Bool {
+        self.accessibilityReduceMotion
+    }
+}
+```
+
+⚠️ Swift で `UIAccessibility` を使うには `import UIKit` が必要。ファイル先頭に `import UIKit` がなければ追加（既存 `import SwiftUI` の下）。
+
+- [ ] **Step 3: テスト2件がPASSすることを確認**
+
+```bash
+xcodebuild test -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+  -only-testing:BubblePopGameTests/CriticalBugFixTests/accessibleColorReturnsHighContrast \
+  -only-testing:BubblePopGameTests/CriticalBugFixTests/highContrastRedIsPureRed 2>&1 | tail -10
+```
+Expected: 2件 PASS
+
+- [ ] **Step 4: 全テストPASS確認**
+
+```bash
+xcodebuild test -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' 2>&1 | tail -10
+```
+Expected: `** TEST SUCCEEDED **`
+
+- [ ] **Step 5: シミュレータで目視確認（手動・任意）**
+
+シミュレータ → 設定 → アクセシビリティ → 表示とテキストサイズ → コントラストを上げる → ON
+→ アプリ再起動 → メニュー画面の色が高コントラストになることを確認（赤・青・緑が純色に近くなる）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add app/BubblePopGame/Utils/AccessibilityUtils.swift \
+        app/BubblePopGameTests/CriticalBugFixTests.swift
+git commit -m "$(cat <<'EOF'
+fix(AccessibilityUtils): 高コントラスト判定を有効化
+
+isHighContrastEnabled が常に false 返却の簡略実装だったため、
+視覚支援を必要とするユーザに高コントラスト色が適用されなかった。
+UIAccessibility.isDarkerSystemColorsEnabled を返すよう修正。
+
+- import UIKit 追加
+- 色変換ロジックの回帰テスト追加
+
+refs #5 Phase 1 (1.4)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: 統合検証
+
+**Files:** （変更なし、検証のみ）
+
+- [ ] **Step 1: クリーンビルド**
+
+```bash
+xcodebuild clean -project app/BubblePopGame.xcodeproj -scheme BubblePopGame
+xcodebuild build -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -configuration Debug \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' 2>&1 | tail -10
+```
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 2: Release configuration ビルド**
+
+```bash
+xcodebuild build -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -configuration Release \
+  -destination 'generic/platform=iOS' 2>&1 | tail -10
+```
+Expected: `** BUILD SUCCEEDED **`、警告は無視可（PR4でprint削除予定）
+
+- [ ] **Step 3: 全テストPASS**
+
+```bash
+xcodebuild test -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' 2>&1 | tail -30
+```
+Expected: `** TEST SUCCEEDED **`、CriticalBugFixTests 全件PASS
+
+- [ ] **Step 4: シミュレータでフル walk-through**
+
+`Skill: ios-simulator-app-verification` で以下を実行・スクショ:
+1. 初回起動 → LaunchScreen → メニュー
+2. 設定 → gameTime=30s → 戻る
+3. 普通モード開始 → バブルタップ × 数回 → パーティクル演出確認 → ゲームオーバー
+4. GameOver 画面で「プレイ時間」が 30s 程度の経過時間を表示することを確認
+5. 設定 → gameTime=120s → 戻る → 開始 → ProgressView が 120 起点で減ることを確認
+6. iPad シミュレータでも起動 → バブルが画面外に出ないことを確認
+
+- [ ] **Step 5: ベースライン比較**
+
+```bash
+git diff main --stat
+```
+変更行数が想定範囲内（150-250行程度）であることを確認。
+
+---
+
+## Task 6: PR 作成
+
+**Files:** （変更なし、Git操作のみ）
+
+- [ ] **Step 1: ブランチを origin に push**
+
+```bash
+git push -u origin feature/issue-5-pr1-critical-bugs
+```
+
+- [ ] **Step 2: gh pr create で PR 作成**
+
+```bash
+gh pr create --title "fix: Phase 1 致命的バグ4件修正 (Issue #5 PR1)" --body "$(cat <<'EOF'
+## Summary
+Issue #5「審査出す準備＋ローカライゼーション」のクリティカルパス先頭。
+release-action-plan.md Phase 1 の致命的バグ4件をTDDで修正。
+
+- 1.1 GameViewModel.screenBounds 初期値ハードコード → .zero に変更＋startGameでガード
+- 1.2 GameView ProgressView と GameOverView の 60秒固定 → gameSettings.gameTime 参照に
+- 1.3 ParticleEffectView struct→@Observable class分離（パーティクル演出が見えない真の原因を解決）
+- 1.4 AccessibilityUtils.isHighContrastEnabled の簡略 false 返却を UIAccessibility 実値に
+
+## Test plan
+- [ ] xcodebuild test 全PASS（CriticalBugFixTests を含む）
+- [ ] gameTime=30/60/120s でタイマーバーとGameOver経過時間が正しく動作（目視）
+- [ ] バブルタップでパーティクル演出が表示・1.5秒で消える（目視）
+- [ ] 高コントラスト設定ONで色が純色に近づく（任意）
+- [ ] iPhone・iPad両方のシミュレータで動作（バブル画面外配置なし）
+
+refs #5
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: PR URLをユーザーに報告**
+
+`gh pr view --json url -q .url` の出力を伝える
+
+---
+
+## 自己レビュー（実装エージェント向けチェックリスト）
+
+実装完了後、以下を確認:
+
+1. **Spec coverage**: 親プラン PR1 の4つのバグが全て対応されているか
+2. **Placeholder scan**: "TODO", "後で" などのPlaceholderが残っていないか
+3. **Type consistency**: `setupParticleEffectView` → `setupParticleEffectViewModel` のリネームが全箇所適用されているか:
+   ```bash
+   grep -rn "setupParticleEffectView\b" app/BubblePopGame --include="*.swift"
+   grep -rn "particleEffectView\b" app/BubblePopGame --include="*.swift" | grep -v "Tests.swift"
+   ```
+   後者の出力は `particleEffectViewModel` だけになるべき（テスト除く）
+
+4. **ダウンキャスト残存**: `as? EffectServiceImpl` は **意図的に残す**（PR3で除去予定）。grep で残存が1箇所のみ（GameViewModel.setupParticleEffectViewModel内）を確認
+
+---
+
+## 参考: 関連スキル
+
+| スキル | 用途 |
+|--------|------|
+| `superpowers:test-driven-development` | Task 1〜4 のテスト → 実装の流れ |
+| `superpowers:verification-before-completion` | Task 5 統合検証 |
+| `superpowers:finishing-a-development-branch` | Task 6 PR作成 |
+| `ios-simulator-app-verification` | Task 2.6, 3.10, 5.4 シミュレータ動作確認 |
+
+---
+
+*作成日: 2026-05-17*
+*対象Issue: [#5 審査出す準備＋ローカライゼーション](https://github.com/es0612/BubblePopGame/issues/5) — PR1 致命バグ修正*
+*親プラン: `plans/github-issue-federated-music.md`*

--- a/plans/github-issue-federated-music.md
+++ b/plans/github-issue-federated-music.md
@@ -1,0 +1,469 @@
+# Issue #5: 審査出す準備＋ローカライゼーション 対応計画
+
+> **注記**: プランファイル名は `github-issue-federated-music.md` ですが、システムの制約で変更不可のため
+> 内容を Issue #5 用に書いています。実装フェーズで `plans/issue-5-app-store-release.md` 等にリネーム推奨。
+
+---
+
+## Context
+
+GitHub Issue [#5「審査出す準備＋ローカライゼーション」](https://github.com/es0612/BubblePopGame/issues/5) は本文空のサマリーIssueで、内容は既存の `docs/release-action-plan.md`（2025-09-23作成、Phase 1〜5）に紐づく。BubblePopGameは機能実装は完了済（テスト全PASS、日英Localizable.strings実装済み）だが、**App Store審査に出すためには以下のブロッカー解消が必要**:
+
+- 致命的バグ4件（画面サイズ初期化／時間表示不整合／ParticleEffectView状態更新／高コントラスト無効化）
+- `PrivacyInfo.xcprivacy` 未実装（iOS 17+で必須、ITMS-91053リスク）
+- ローカライズ漏れ（ハードコード文字列11箇所、`knownRegions` に `ja` 未登録）
+- 設定値が固定値で反映されないバグ
+- デバッグ用print文 約37箇所
+- App Storeスクリーンショット未作成
+- TestFlight検証未実施
+
+**期待される成果**: v1.0.0 を App Store Connect に提出可能な状態にする。
+
+**ユーザー方針**（確認済み）:
+- スコープ: release-action-plan の **全Phase（1〜5）** に取り組む
+- PR戦略: **テーマ別に分割**（致命バグ／L10n／機能バグ／プロダクション準備／App Store申請）
+
+---
+
+## 推奨アプローチ
+
+release-action-plan.md の Phase 1〜5 をテーマ別の独立PRに分割し、`superpowers:writing-plans` → `superpowers:executing-plans` の流れでPRごとにイテレーション。Phase 4（コード品質改善）は v1.0 提出後に延期。
+
+### PR一覧と依存関係
+
+| # | タイトル | 対応 Phase | 依存 | 並行可 | 工数目安 | 必須/任意 |
+|---|---------|----------|------|--------|---------|---------|
+| **PR1** | 致命的バグ修正（画面サイズ／時間表示／パーティクル／HCM） | Phase 1 | なし | PR2と並行可 | 0.5〜1日 | **必須** |
+| **PR2** | ローカライゼーション完成（ハードコード除去＋knownRegions＋未翻訳追加） | Phase 2 #6 | なし | PR1と並行可 | 0.5〜1日 | **必須** |
+| **PR3** | 機能バグ修正（設定値反映＋DI＋パフォーマンス回復） | Phase 2 #5,7,8 | PR1マージ後推奨 | PR2と並行可 | 0.5〜1日 | **必須** |
+| **PR4** | プロダクション準備（PrivacyInfo＋print削除＋TODO解決＋テスト追加） | Phase 3 | PR1〜3 | 単独 | 1日 | **必須** |
+| **PR5** | コード品質改善（GameViewModel／TutorialView分割等） | Phase 4 | PR4 | 単独 | 1〜2日 | 任意（v1.0後に延期） |
+| **PR6** | App Store申請（スクショ／TestFlight／メタデータ確認） | Phase 5 | PR1〜4 | 単独 | 1日 | **必須** |
+
+**クリティカルパス**: PR1+PR2+PR3 → PR4 → PR6
+
+---
+
+## PR1 — 致命的バグ修正 (Phase 1)
+
+### 目的
+ゲームプレイを破壊する4件の致命的バグを修正し、審査時のクラッシュ／不正動作リスクをゼロにする。
+
+### 対象ファイル
+- `app/BubblePopGame/ViewModels/GameViewModel.swift`（行 19, 95-108, 116-119）
+- `app/BubblePopGame/Views/Game/GameView.swift`（行 134, 154-156）
+- `app/BubblePopGame/Views/GameOver/GameOverView.swift`（行 102-104）
+- `app/BubblePopGame/Views/Effects/ParticleEffectView.swift`（行 10-28）
+- `app/BubblePopGame/Utils/AccessibilityUtils.swift`（行 131）
+
+### TODO
+
+#### 1.1 画面サイズ初期化問題
+- [ ] `GameViewModel.swift:19` の `screenBounds` デフォルトを `CGRect.zero` に変更
+- [ ] `startGame()` 内で `screenBounds == .zero` のときバブル生成を遅延
+- [ ] `GameView.onAppear` の `updateScreenBounds(geometry.frame)` 呼び出し維持を確認
+- [ ] 画面回転時の境界更新を確認
+- [ ] テスト追加: `GameViewModelTests.initialScreenBounds`
+
+#### 1.2 時間表示不整合
+- [ ] `GameView.swift:134`: `total: 60.0` → `total: viewModel.gameSettings.gameTime`
+- [ ] `GameOverView.swift:102-104`: `60.0 - viewModel.timeRemaining` 3箇所を `viewModel.gameSettings.gameTime - viewModel.timeRemaining` に置換
+- [ ] テスト追加: gameTime=30s/60s/120s/180s 各設定で経過時間正常
+
+#### 1.3 ParticleEffectView 状態更新問題
+- [ ] `ParticleEffectView` を `@Observable class ParticleEffectViewModel` 形式に分離
+- [ ] `EffectServiceImpl.particleEffectView` を ViewModel 参照に変更
+- [ ] `GameView.swift:12` の `@State private var particleEffectView` をViewModelパターンに置換
+- [ ] バブルタップ→パーティクル発生→1.5秒で消える挙動を目視確認
+
+#### 1.4 アクセシビリティ高コントラスト
+- [ ] `AccessibilityUtils.swift:131` を `UIAccessibility.isDarkerSystemColorsEnabled` 返却に修正
+- [ ] iOS設定→アクセシビリティ→コントラストを上げる ON時に色変化を確認
+
+### テスト方法
+```bash
+xcodebuild test -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest'
+```
+- `Skill: ios-simulator-app-verification` でビルド・起動・基本フロー確認
+- 設定変更後ゲーム開始でタイマー反映確認
+
+### 完了基準
+- [ ] 4件のバグ修正完了 / 全テストPASS / 30s〜180s各設定で完走 / iPhone・iPad両方で動作確認
+
+---
+
+## PR2 — ローカライゼーション完成 (Phase 2 #6)
+
+### 目的
+- 全ハードコード文字列を `NSLocalizedString` 経由に置換
+- `knownRegions` に `ja` を登録（**重要：現在 `(en, Base)` のみで `ja` 未登録**）
+- App Store提出時の多言語対応を完全化
+
+### 対象ファイル
+- `app/BubblePopGame.xcodeproj/project.pbxproj`（行 192-195、`knownRegions`）
+- `app/BubblePopGame/{ja,en,Base}.lproj/Localizable.strings`
+- `app/BubblePopGame/Views/LaunchScreenView.swift`（行 68-74）
+- `app/BubblePopGame/Views/HighScore/HighScoreRow.swift`（行 32, 42, 48, 54, 60）
+- `app/BubblePopGame/Views/HighScore/HighScoreView.swift`（行 44）
+- `app/BubblePopGame/Views/Game/PauseOverlayView.swift`（行 42, 65, 86, 94）
+- `app/BubblePopGame/Views/Game/BubbleView.swift`（行 42-43）
+- `app/BubblePopGame/Views/TutorialView.swift`（行 49）
+- `app/BubblePopGame/ContentView.swift`（行 43, 50）
+
+### TODO
+
+#### 2.0 プロジェクト設定（最優先）
+- [ ] `project.pbxproj:192-195` `knownRegions = (en, Base);` → `knownRegions = (en, ja, Base);`
+- [ ] Xcode → Project → Info → Localizations に `Japanese` が表示されることを確認
+- [ ] ビルド成果物の `.app/ja.lproj/` 存在確認
+
+#### 2.1 新規ローカライゼーションキー追加（ja/en/Base 全てに19キー）
+
+| キー | ja | en |
+|------|----|----|
+| `loading_settings` | 設定読み込み中... | Loading settings... |
+| `loading_initialization` | 初期化中... | Initializing... |
+| `accessibility_skip_tutorial_hint` | チュートリアルをスキップしてメニューに進みます | Skip tutorial and go to menu |
+| `accessibility_resume_game_hint` | ゲームを再開します | Resume the game |
+| `accessibility_quit_game_hint` | ゲームを終了してメニューに戻ります | End the game and return to menu |
+| `pause_quit_confirm_title` | ゲーム終了の確認 | Confirm Game Exit |
+| `pause_quit_confirm_message` | 本当にゲームを終了しますか？\n現在のゲームは終わります。 | Are you sure you want to quit the game?\nThe current game will be ended. |
+| `bubble_accessibility_numbered` | 数字%dのシャボン玉 | Bubble with number %d |
+| `bubble_accessibility_normal` | シャボン玉 | Bubble |
+| `bubble_accessibility_hint` | タップすると破裂します | Tap to pop |
+| `highscore_game_mode_normal` | 通常 | Normal |
+| `highscore_game_mode_numbered` | 数字順 | Numbered |
+| `highscore_bubbles_popped_label` | 破裂数: %d | Bubbles popped: %d |
+| `highscore_accuracy_label` | 正確率: %@ | Accuracy: %@ |
+| `highscore_time_limit_label` | 制限時間: %d秒 | Time limit: %d sec |
+| `highscore_play_duration_label` | プレイ時間: %.1f秒 | Play time: %.1fs |
+| `highscore_time_limit_picker_label` | 制限時間 | Time limit |
+| `launch_screen_title_main` | シャボン玉消しゲーム | Bubble Pop Game |
+| `launch_screen_title_sub` | Bubble Pop Game | Pop the bubbles! |
+
+#### 2.2〜2.8 各ファイルのハードコード置換
+- [ ] `ContentView.swift:43,50`: `ProgressView("設定読み込み中...")` / `"初期化中..."` → `NSLocalizedString` 経由
+- [ ] `LaunchScreenView.swift:68,74`: タイトル2行を `launch_screen_title_main/sub` に置換
+- [ ] `HighScoreRow.swift:32,42,48,54,60`: 5箇所のText文字列を `NSLocalizedString(format:)` 化
+- [ ] `HighScoreView.swift:44`: `Picker("制限時間", ...)` → `NSLocalizedString("highscore_time_limit_picker_label", ...)`
+- [ ] `PauseOverlayView.swift:42,65,86,94`: accessibilityHint と alert を全てローカライズ
+- [ ] `BubbleView.swift:42-43`: accessibilityLabel と accessibilityHint をローカライズ
+- [ ] `TutorialView.swift:49`: accessibilityHint をローカライズ
+
+#### 2.9 String Catalog 移行（任意・推奨度低）
+- [ ] **デフォルトでは実施しない**。v1.0提出後に判断
+- [ ] 実施する場合は `Skill: xcstrings-bulk-update` を使用
+
+### テスト方法
+- `Skill: ios-simulator-locale-testing` で ja/en 切り替えての全7画面（Launch/Menu/Tutorial/Game/Pause/GameOver/HighScore/Settings）スクショ取得
+- 並べて目視review（ハードコード残存ゼロ確認）
+
+### 完了基準
+- [ ] `knownRegions` に `ja` 追加済み
+- [ ] 19キー全て3言語に追加
+- [ ] 全ハードコードText/Picker/alert/accessibility が `NSLocalizedString` 経由
+- [ ] ja・en両方で全画面スクショ取得し残存ハードコードなし
+
+---
+
+## PR3 — 機能バグ修正 (Phase 2 #5, #7, #8)
+
+### 目的
+設定値の未反映・DIダウンキャスト・パフォーマンス回復ロジック不在の3件を修正。
+
+### 対象ファイル
+- `app/BubblePopGame/Services/BubbleService.swift`（行 31-71）
+- `app/BubblePopGame/ViewModels/GameViewModel.swift`（行 95-108, 110-113）
+
+### TODO
+
+#### 3.1 設定値反映（BubbleService）
+- [ ] `BubbleService` に `updateSettings(_ settings: GameSettings)` を追加（**案B採用**）
+- [ ] `BubbleServiceImpl` に `private var gameSettings: GameSettings?` を保持
+- [ ] `createBubble(at:type:)` の radius 計算で `settings.bubbleMinRadius...bubbleMaxRadius` を使用
+- [ ] `updateBubbles(_:)` の `animationPhase` 進行量に `gameSettings?.animationSpeed` を掛ける
+- [ ] `GameViewModel.init` / `reloadGameSettings()` / `ContentView.setupDependencies` で `updateSettings` 呼び出し
+- [ ] Settings画面でbubbleCount=10/50, animationSpeed=2.0 → ゲーム開始 → 即座反映確認
+
+#### 3.2 依存性注入問題
+- [ ] `GameViewModel.swift:110-113` の `effectService as? EffectServiceImpl` ダウンキャストを除去
+- [ ] `EffectService` プロトコルに `attachParticleEffectViewModel(_:)` 追加
+- [ ] `EffectServiceImpl.particleEffectView` を private 化
+- [ ] grep で `as? EffectServiceImpl` 残存ゼロ確認
+
+#### 3.3 パフォーマンス回復ロジック
+- [ ] `GameViewModel.optimizePerformance()` に「削減後の回復ロジック」を追加
+- [ ] `PerformanceService.shouldRestoreBubbles() -> Bool` を追加
+- [ ] `updateGame()` の1秒チェックブロックで `shouldRestoreBubbles()` も判定
+- [ ] テスト追加: "削減→負荷回復→再増加" シナリオ
+
+### 完了基準
+- [ ] 設定変更がバブルサイズ／速度／個数に即座反映
+- [ ] `effectService as? EffectServiceImpl` 残存ゼロ（grep確認）
+- [ ] パフォーマンス回復シナリオの単体テストPASS
+
+---
+
+## PR4 — プロダクション準備 (Phase 3 + PrivacyInfo)
+
+### 目的
+- **`PrivacyInfo.xcprivacy` 追加（App Store審査ブロッカー解消、最優先）**
+- print文約37箇所をOSLog化 or #if DEBUG化
+- `MenuViewModel` のTODO 2件解決
+- 主要フローの回帰テスト拡充
+
+### 対象ファイル
+**新規**:
+- `app/BubblePopGame/PrivacyInfo.xcprivacy`
+- `app/BubblePopGame/Utils/AppLogger.swift`
+- `app/BubblePopGameTests/MenuViewModelTests.swift`
+- `app/BubblePopGameTests/SettingsFlowTests.swift`
+- `app/BubblePopGameTests/ScoreSaveTests.swift`
+
+**修正**:
+- `app/BubblePopGame/ViewModels/MenuViewModel.swift`（行 19-25）
+- `app/BubblePopGame/Services/AudioService.swift`（最大20箇所）
+- `app/BubblePopGame/Services/EffectService.swift`、その他 print文ある全ファイル
+
+### TODO
+
+#### 4.1 PrivacyInfo.xcprivacy 作成（最優先）
+- [ ] grepでUserDefaults/AppStorage使用ゼロ再確認（**確認済**）
+- [ ] `app/BubblePopGame/PrivacyInfo.xcprivacy` 作成:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array/>
+</dict>
+</plist>
+```
+
+**根拠**: ネットワーク通信なし・追跡なし・データ収集なし（SwiftDataローカル保存のみ）・UserDefaults使用ゼロ
+
+- [ ] `PBXFileSystemSynchronizedRootGroup` 機構で自動認識されるが、Build Phases → Copy Bundle Resources に含まれていることを確認
+- [ ] DerivedData配下に `PrivacyInfo.xcprivacy` 出力確認
+
+#### 4.2 OSLog ベースの統一ロガー
+- [ ] `app/BubblePopGame/Utils/AppLogger.swift` 作成:
+```swift
+import Foundation
+import os.log
+enum AppLogger {
+    private static let subsystem = "com.asapapalab.BubblePopGame"
+    static let lifecycle  = Logger(subsystem: subsystem, category: "lifecycle")
+    static let settings   = Logger(subsystem: subsystem, category: "settings")
+    static let audio      = Logger(subsystem: subsystem, category: "audio")
+    static let effect     = Logger(subsystem: subsystem, category: "effect")
+    static let performance = Logger(subsystem: subsystem, category: "performance")
+    static let highscore  = Logger(subsystem: subsystem, category: "highscore")
+    static let tutorial   = Logger(subsystem: subsystem, category: "tutorial")
+    static let storage    = Logger(subsystem: subsystem, category: "storage")
+}
+```
+
+#### 4.3 print文置換（約37箇所）
+- [ ] Error系（保持・OSLog化）: ContentView/SettingsViewModel/GameViewModel/BubblePopGameApp/TutorialView/HighScoreView/AudioService の各error出力
+- [ ] Info系（DEBUG限定）: `EffectService:47` の高頻度ログは削除、AudioService の探索/再生ログは `#if DEBUG` で囲み debug レベル化
+- [ ] 検証: `grep -rn "print(" app/BubblePopGame --include="*.swift" | grep -v "// "` で残存ゼロ
+
+#### 4.4 MenuViewModel TODO解決
+- [ ] `MenuViewModel.init(scoreRepository:)` に変更、`loadHighScores()` を Repository経由実装
+- [ ] `ContentView.setupDependencies` で `MenuViewModel(scoreRepository: scoreRepository)` 渡す
+- [ ] `navigateToGame()` は YAGNI のため削除（現状 MenuView が gameViewModel.startGame() 直接呼び）
+
+#### 4.5 テスト追加
+- [ ] `MenuViewModelTests`: `loadHighScores_withRepository_populatesArray` 等3ケース
+- [ ] `SettingsFlowTests`: `settingsChange_reflectedInGameStart`
+- [ ] `ScoreSaveTests`: `endGame_savesScore` / `endGame_updatesStatistics`
+
+#### 4.6 リリースビルド設定
+- [ ] Release configurationの最適化レベル `-O` 確認
+- [ ] Strip Linked Product = YES、Symbols Hidden = YES
+
+### 完了基準
+- [ ] `PrivacyInfo.xcprivacy` が `.app` バンドルに含まれる
+- [ ] print文残存ゼロ（grep確認）
+- [ ] MenuViewModel TODO 2件解決
+- [ ] 新規テスト3ファイルPASS / 全テストPASS / Release ビルド警告ゼロ
+
+---
+
+## PR5 — コード品質改善 (Phase 4)【任意・v1.0後に延期推奨】
+
+v1.0 提出のクリティカルパス外。**別Issueとして切り出し推奨**。
+
+スケッチのみ:
+- GameViewModel.swift (701行) → `GameLogicService` / `GameTimerService` に分割、目標<400行
+- TutorialView.swift (540行) → step別ファイル化、目標<300行
+- Timer管理を `TimerManager` で統一
+- `DispatchQueue.main.asyncAfter` × 8箇所を async/await に移行
+- ContentView.swift の `setupDependencies` を `DependencyContainer` に切り出し
+
+---
+
+## PR6 — App Store 申請 (Phase 5)
+
+### 目的
+スクリーンショット生成、App Store Connect設定、TestFlight配信、メタデータ最終確認。
+
+### TODO
+
+#### 6.1 バージョン番号確認
+- [ ] **`Skill: release-version-bump-check`** でバージョン妥当性検証
+- [ ] 初回提出のため `MARKETING_VERSION=1.0`、`CURRENT_PROJECT_VERSION=1` のまま（ITMS-90186/90062リスクなし）
+
+#### 6.2 スクリーンショット生成
+- [ ] **`Skill: ios-simulator-locale-testing`** で撮影
+- [ ] 必須サイズ: iPhone 6.7"/6.9"（必須）、iPad 13"（iPad対応のため必須）
+- [ ] 各サイズ × ja/en × 5画面 = 20枚:
+  1. メインメニュー
+  2. ゲーム中（通常モード）
+  3. ゲーム中（数字順モード）
+  4. ハイスコア画面
+  5. 設定画面
+- [ ] 出力先: `/screenshot/{device}/{locale}/{screen}.png`
+- [ ] ステータスバー固定:
+  ```bash
+  xcrun simctl status_bar booted override --time "9:41" --batteryState charged \
+    --batteryLevel 100 --wifiBars 3 --cellularBars 4
+  ```
+
+#### 6.3 アプリアイコン最終確認
+- [ ] 1024×1024 Light/Dark/Tinted 揃い（探索済）
+- [ ] 透過なし・角丸処理なしの生PNG確認
+
+#### 6.4 App Store Connect セットアップ
+- [ ] 新規アプリ作成（Bundle ID: `com.asapapalab.BubblePopGame`）
+- [ ] `docs/app-store-metadata.md` の内容を転記（アプリ名/サブタイトル/キーワード/説明文）
+- [ ] サポートURL・プライバシーポリシーURL（`docs/privacy-policy.md` をGitHub Pages等で公開）登録
+- [ ] カテゴリ: ゲーム > カジュアル / 年齢制限: 4+ / 価格: 無料 / IAP: なし
+- [ ] App Privacy: "Data Not Collected"（`PrivacyInfo.xcprivacy` と整合）
+
+#### 6.5 TestFlight 配信
+- [ ] Xcode → Product → Archive で Release ビルド
+- [ ] Validate App で警告ゼロ確認
+- [ ] Distribute App → App Store Connect → Upload
+- [ ] Processing完了後 Internal Testing に自分を追加 → 実機 walk-through:
+  - 初回起動→チュートリアル→メニュー
+  - 各ゲームモード × 各時間設定 × 各BGM
+  - ハイスコア / 設定リセット / バックグラウンド復帰 / 機内モード動作
+
+#### 6.6 申請前最終チェック
+- [ ] PrivacyInfo含む / サポートURL・プライバシーポリシーURL公開済 / スクショ20枚アップロード
+- [ ] Export Compliance: 「暗号化未使用」/ Release Notes記載 / 「審査待ち」状態で提出
+
+### 完了基準
+- [ ] ASCに v1.0 (Build 1) を「審査待ち」でアップロード
+- [ ] TestFlight Internal Testingで実機動作確認完了
+- [ ] スクショ20枚アップロード済 / App Privacy "Data Not Collected" 確定
+
+---
+
+## 統合検証（全PR完了後・PR6前）
+
+```bash
+# クリーンビルド
+xcodebuild clean -project app/BubblePopGame.xcodeproj -scheme BubblePopGame
+
+# Debug / Release / Test 全実行
+xcodebuild build -project app/BubblePopGame.xcodeproj -scheme BubblePopGame -configuration Debug \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest'
+xcodebuild build -project app/BubblePopGame.xcodeproj -scheme BubblePopGame -configuration Release \
+  -destination 'generic/platform=iOS'
+xcodebuild test -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest'
+
+# Code Quality grep
+grep -rn "print(" app/BubblePopGame --include="*.swift" | grep -v "// "      # → 0行期待
+grep -rn "TODO\|FIXME" app/BubblePopGame --include="*.swift"                  # → MenuViewModel解決済確認
+grep -rn "as? EffectServiceImpl" app/BubblePopGame --include="*.swift"        # → 0行期待
+
+# PrivacyInfo 検証
+find ~/Library/Developer/Xcode/DerivedData -path "*BubblePopGame*" -name "PrivacyInfo.xcprivacy"
+```
+
+- `Skill: ios-simulator-locale-testing` で ja/en 全7画面スクショ取得→残存ハードコードゼロ確認
+- `Skill: ios-simulator-app-verification` で全フロー walk-through
+- iPhone実機（iOS 17.x）で TestFlight 配信前検証
+
+---
+
+## 利用スキル一覧
+
+| スキル | 利用PR | 用途 |
+|--------|--------|------|
+| `superpowers:writing-plans` | PR1〜PR6 | 各PR詳細計画 |
+| `superpowers:executing-plans` | PR1〜PR6 | 各PR実装 |
+| `superpowers:test-driven-development` | PR1, PR3, PR4 | バグ修正前のテスト追加 |
+| `superpowers:verification-before-completion` | 全PR | マージ前検証 |
+| `superpowers:finishing-a-development-branch` | 全PR | PR作成・マージ |
+| `ios-simulator-app-verification` | PR1, PR3, PR4 | シミュレータ動作確認 |
+| `ios-simulator-locale-testing` | PR2, PR6 | ja/en切り替え検証＋スクショ |
+| `xcstrings-bulk-update` | PR2（任意） | String Catalog 移行 |
+| `release-version-bump-check` | PR6 | バージョン妥当性 |
+
+---
+
+## リスクと対策
+
+| リスク | 影響 | 対策 |
+|--------|------|------|
+| `knownRegions` 修正で既存 ja.lproj が壊れる | ja表示不可 | PR2で `ja` 追加後、必ず ja シミュレータで動作確認 |
+| `ParticleEffectView` 構造変更でUI崩壊 | パーティクル非表示 | PR1でTDD（先にテスト追加） |
+| `PrivacyInfo.xcprivacy` 申告漏れ | 審査リジェクト | UserDefaults等の使用箇所をgrep再確認（**現時点ゼロ確認済**） |
+| プライバシーポリシーURL未公開 | 申請不可 | PR6開始前にGitHub Pages公開、ASC登録 |
+| TestFlight実機検証でiOS 17未対応バグ | 提出延期 | iPhone 12 (iOS 17.x) 等で確認 |
+
+---
+
+## Critical Files for Implementation
+
+最重要5ファイル:
+- `/Users/shinya/workspace/claude/BubblePopGame/app/BubblePopGame.xcodeproj/project.pbxproj`（PR2 `knownRegions`、PR4 PrivacyInfo登録確認）
+- `/Users/shinya/workspace/claude/BubblePopGame/app/BubblePopGame/PrivacyInfo.xcprivacy`（**PR4新規・審査ブロッカー解消**）
+- `/Users/shinya/workspace/claude/BubblePopGame/app/BubblePopGame/ViewModels/GameViewModel.swift`（PR1致命バグ／PR3 DI・パフォーマンス／PR4 print削除）
+- `/Users/shinya/workspace/claude/BubblePopGame/app/BubblePopGame/{ja,en,Base}.lproj/Localizable.strings`（PR2で19キー追加）
+- `/Users/shinya/workspace/claude/BubblePopGame/app/BubblePopGame/Services/BubbleService.swift`（PR3設定値反映の中核）
+
+副次的に重要:
+- `app/BubblePopGame/Views/Effects/ParticleEffectView.swift`（PR1状態更新バグ）
+- `app/BubblePopGame/Utils/AppLogger.swift`（PR4新規）
+- `app/BubblePopGame/Views/Game/PauseOverlayView.swift`（PR2 L10n漏れ集中）
+
+---
+
+## 作業順序（推奨タイムライン）
+
+```
+Day 1: PR1（致命バグ）と PR2（L10n）を並行で実装→マージ
+Day 2: PR3（機能バグ）実装→マージ → PR4（プロダクション準備）開始
+Day 3: PR4 続き → マージ → 統合検証チェックリスト実行
+Day 4: PR6（App Store申請）→ TestFlight → ASC提出
+Day 5+: PR5（コード品質）は別Issue化、v1.0提出後の保守タスク
+```
+
+---
+
+## 次のアクション
+
+1. このプラン承認後、**PR1から `superpowers:writing-plans` でPR単位の詳細計画を作成**
+2. 各PRごとに `superpowers:executing-plans` で実装
+3. PR間で `superpowers:verification-before-completion` を通す
+4. 最終的に `superpowers:finishing-a-development-branch` でmainにマージ
+
+---
+
+*作成日: 2026-05-17*
+*対象Issue: [#5 審査出す準備＋ローカライゼーション](https://github.com/es0612/BubblePopGame/issues/5)*
+*ベース資料: `docs/release-action-plan.md`*


### PR DESCRIPTION
## Summary
Issue #5「審査出す準備＋ローカライゼーション」のクリティカルパス先頭。
[`docs/release-action-plan.md`](../blob/main/docs/release-action-plan.md) **Phase 1** の致命的バグ4件をTDDで一括修正。

### 修正内容
1. **1.1 GameViewModel.screenBounds 初期値ハードコード除去** — `CGRect(393x852)` 固定 → `.zero` + `startGame()` で `.zero` ガード
2. **1.2 60秒固定の時間表示を `gameSettings.gameTime` 参照に** — `GameView.swift:134` ProgressView と `GameOverView.swift:102-104` 経過時間3式
3. **1.3 ParticleEffectView struct→@Observable class 分離** — 値型コピー問題でパーティクル演出が見えない真の原因を解決
4. **1.4 AccessibilityUtils.isHighContrastEnabled の簡略 false 返却を修正** — `UIAccessibility.isDarkerSystemColorsEnabled` を返却

### ドキュメント更新
- `CLAUDE.md`: xcodebuild の destination 修正（iPhone 16→17 Pro）、MainActor 隔離の落とし穴、View 修正の検証戦略、Git運用ルールを追記
- `.gitignore`: `build/`、`DerivedData/` を追加

### 設計判断
- **`as? EffectServiceImpl` ダウンキャストは PR3 で除去予定**（DI改善の一環）。本PRでは Particle 修正に伴う型変更のみで最小スコープ維持
- `EffectServiceImpl` を `@MainActor` 化（`addEffect` が MainActor isolated のため）→ Swift 6 警告は #7 で対応

### 関連改善 Issue（PR1セッション振り返りから別途分離）
- #7 EffectService プロトコルの @MainActor 化（Swift 6 対応）
- #8 デバッグビルド時のチュートリアル/オンボーディングスキップ機構
- #9 release-action-plan.md / docs の更新（Phase 1 完了反映）

## Test plan
### 自動テスト ✅
- [x] `CriticalBugFixTests` 新規9件 全PASS（iPhone 17 Pro Simulator）
- [x] 既存ユニットテスト全PASS
- [x] Debug ビルド成功
- [x] Release ビルド成功（シミュレータ向け）

### 自動起動確認 ✅
- [x] iPhone 17 Pro シミュレータでクラッシュなく起動・チュートリアル表示
- [x] iPad Pro 12.9-inch シミュレータでクラッシュなく起動

### 手動 walk-through（マージ前に要実施）⚠️
`simctl` には `tap` がなく、`isFirstLaunch` が SwiftData 永続化のため自動化困難（→ Issue #8 で改善予定）。以下を**マージ前に手動確認**してください:

- [ ] チュートリアルをスキップ → メニュー表示
- [ ] 設定で `gameTime=120s` → ゲーム開始 → **ProgressView が満タンから減ること**（旧コードでは即満タン固定の不具合）
- [ ] バブルをタップ → **パーティクル演出（1.5秒）が表示されること**（旧コードでは表示されない真の原因）
- [ ] ゲーム終了 → GameOver の「プレイ時間」が **gameTime - 残り時間** として正しく表示
- [ ] iOS設定 → アクセシビリティ → コントラストを上げる ON → 色が純色（赤=Pure red 等）に近づく

## 関連プラン
- 親プラン: [`plans/github-issue-federated-music.md`](../blob/feature/issue-5-pr1-critical-bugs/plans/github-issue-federated-music.md)（Issue #5 全体）
- 本PR詳細: [`plans/2026-05-17-pr1-critical-bugs.md`](../blob/feature/issue-5-pr1-critical-bugs/plans/2026-05-17-pr1-critical-bugs.md)

refs #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)