### PR TITLE
fix: ContentView 初期化時に screenBounds をセットして startGame デッドロックを解消

### DIFF
--- a/app/BubblePopGame/ContentView.swift
+++ b/app/BubblePopGame/ContentView.swift
@@ -135,13 +135,18 @@ struct ContentView: View {
             gameSettings: gameSettings
         )
         
+        // GameView マウント前でも MenuView の Start ボタン経由で startGame() が
+        // 呼ばれる経路があるため、ここで screenBounds を初期化しておく。
+        // （GameViewModel.startGame() の guard が .zero で early-return する）
+        viewModel.updateScreenBounds(CGRect(origin: .zero, size: screenSize))
+
         // 初回起動時はチュートリアル、そうでなければメニュー
         if gameSettings.isFirstLaunch {
             viewModel.gameState = .tutorial
         } else {
             viewModel.gameState = .menu
         }
-        
+
         self.gameViewModel = viewModel
     }
     

--- a/app/BubblePopGameTests/CriticalBugFixTests.swift
+++ b/app/BubblePopGameTests/CriticalBugFixTests.swift
@@ -74,6 +74,23 @@ struct CriticalBugFixTests {
                 "screenBounds 設定後 startGame でバブル生成される")
     }
 
+    @Test("MenuView 経路（GameView マウント前）でも startGame で playing に遷移する")
+    func startGameTransitionsToPlayingFromMenuPath() throws {
+        // 再現シナリオ: ContentView.setupDependencies が screenBounds を
+        // セットしてから gameState を割り当てる、という契約。
+        // この契約が満たされていれば、ユーザーが MenuView の Start ボタン押下時
+        // （GameView.onAppear が走る前）でも startGame() が機能する。
+        let vm = try Self.makeViewModel()
+        vm.updateScreenBounds(CGRect(x: 0, y: 0, width: 400, height: 800))
+        vm.gameState = .menu
+
+        vm.startGame()
+
+        #expect(vm.gameState == .playing,
+                "ContentView 初期化で screenBounds がセット済みなら、Menu からの startGame で .playing に遷移する")
+        #expect(!vm.bubbles.isEmpty)
+    }
+
     // MARK: - 1.2 時間表示
 
     @Test("gameTime=120 で startGame すると timeRemaining も 120")


### PR DESCRIPTION
## Summary

PR #6 で導入された `GameViewModel.startGame()` の `guard screenBounds != .zero` ガードにより、**2回目以降の起動（`isFirstLaunch=false` → Tutorial を経由しない経路）で MenuView の Start ボタンを押してもゲーム画面に遷移できない本番バグ**を修正。

### 根本原因

- `ContentView.swift:56-60` の `.onAppear` は最初の表示時のみ走る。その時点で `gameViewModel == nil` のため `updateScreenBounds` は skip される。
- `setupDependencies` で `gameViewModel` が作られた後、ContentView の `.onAppear` は再呼出されないため `screenBounds` は `.zero` のまま。
- ユーザーが `MenuView` の Start ボタンを押すと `startGame()` → PR #6 で追加された `guard screenBounds != .zero` で early-return → gameState は `.menu` のまま → GameView がマウントされず、GameView.onAppear での `updateScreenBounds` も走らない（デッドロック）。
- **手動 walk-through では Tutorial 画面の `.onAppear`（`TutorialView.swift:126`）が `updateScreenBounds` を呼ぶため、fresh install では再現せず見逃された**。

Xcode Cloud の UITest `testBasicGameInteraction()` の失敗（「スコア表示が見つからない」）が顕在化のトリガー。前段のテストで SwiftData 経由 `isFirstLaunch=false` が永続化された状態で実行される経路に入ると確実に再現する。

### 修正内容

`ContentView.setupDependencies` で gameState を割り当てる前に `viewModel.updateScreenBounds(screenSize)` を1行追加。GameView マウント前でも startGame() が機能する状態を担保する。

### テスト追加

- `CriticalBugFixTests.startGameTransitionsToPlayingFromMenuPath`: Menu 経路（`screenBounds` 設定 → `gameState = .menu` → `startGame()`）で `.playing` に遷移することを検証

## Test plan

### 自動テスト ✅
- [x] `CriticalBugFixTests` 新規含む全件 PASS（iPhone 17 Pro Simulator）
- [x] `BubblePopGameTests` 全件 PASS
- [x] Release ビルド成功

### CI で確認
- [ ] Xcode Cloud で `testBasicGameInteraction()` が緑になる
  - ローカルで UITest Runner が起動失敗するため (`(ipc/mig) server died`)、ローカル検証は CI に委ねる

### マージ前手動確認 ⚠️
- [ ] 一度ゲームを起動して Tutorial をスキップ（`isFirstLaunch=false` を永続化）
- [ ] アプリ完全終了 → 再起動 → **メニュー直接表示** → Start タップ → **ゲーム画面に遷移すること**（修正前は遷移しなかった）

## Follow-up

- `BubblePopGameUITests.testBasicGameInteraction` の score predicate (`label CONTAINS '0' OR '1' OR '2'`) は時間表示「60秒」「30秒」にもマッチするため、ゲーム遷移は検証できるが**スコアの動作自体は検証していない**。別 Issue として改善余地あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)