### PR TITLE
docs: release-action-plan.md Phase 1 完了反映 + CLAUDE.md 学び追記 (#9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,12 @@ app/BubblePopGame/
 - そのため View 層修正は**手動 walk-through が必須**。PR description に「マージ前手動確認チェックリスト」を明記する
 - `simctl` には `tap` がないため、設定変更や tutorial スキップを伴う自動検証は不可。`xcrun simctl io ... screenshot` で起動確認＋クラッシュなしの確認までが自動化の上限
 - 永続化された GameSettings は SwiftData なので `UserDefaults trick`（`xcrun simctl spawn ... defaults write`）が効かない点に注意
+- 永続化フラグ（`isFirstLaunch` 等）で初期化フローが分岐する場合、手動 walk-through は「初回起動」「2回目以降」の両経路を必ず検証する。Tutorial を経由するかどうかで `updateScreenBounds` のような重要な副作用がスキップされ、本番バグの温床になる
+- `guard` で前提条件を弾く修正を入れるときは、その前提条件を供給するコード（例: `screenBounds` をセットする `onAppear`）が、ガードを通過する全ての到達経路で確実に走るかを必ず洗い出す。コメントに「X で供給される」と書くだけでは、X が一部経路でしか実行されないと永続デッドロックになる
+
+### UI テスト設計
+
+- XCUITest の predicate（例: `CONTAINS '0' OR CONTAINS '1'`）は、意図しない他の UI 要素（時間表示の「60 秒」等）にも偽陽性マッチして検証が空転する。スコア／タイマー等の同種数値要素が画面に共存するときは accessibilityIdentifier で厳密に特定する
 
 ### Git運用
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,12 +80,20 @@ app/BubblePopGame/
 - パフォーマンス監視（60FPS維持）を重視
 - オブジェクトプールパターンでメモリ効率化
 - アクセシビリティ対応を忘れずに実装
+- 新規 `.swift` ファイルはフォルダに置くだけでターゲットに自動参加する（本プロジェクトは Xcode 16 の file-system synchronized groups を採用 = `PBXFileSystemSynchronizedRootGroup`）。`project.pbxproj` の手編集は不要。テストファイルも `BubblePopGameTests/` に置けば自動で UnitTest ターゲットに含まれる
 
 ### MainActor 隔離
 
 - `@Observable class` で UI から呼ばれるサービスを書く場合は `@MainActor` 付与（特に `effects` などのSwiftUI状態を変更するメソッド）
 - 実装側だけ `@MainActor` を付けるとプロトコル適合で Swift 6 警告（`conformance ... crosses into main actor-isolated code`）が出るため、プロトコル側にも合わせて付与するのが本筋
 - 既存プロトコルを変えにくい場合は `Task { @MainActor in ... }` でラップする選択肢もあるが、`createPopEffect` のような UI 連動メソッドはレイテンシ的に同期呼び出しが望ましい
+- ⚠️ **「見えない警告」の検証**: 本プロジェクトは `SWIFT_VERSION = 5.0` かつ `SWIFT_STRICT_CONCURRENCY` 未設定（= minimal）のため、上記 conformance 警告は**通常ビルドでは surface しない**。`@MainActor` 化のような Swift 6 対応を修正・検証するときは、`xcodebuild build ... SWIFT_STRICT_CONCURRENCY=complete` で before（警告が出る）/ after（消える）を実測すること。通常 config のままだと「修正したつもり」でも検証不能（View レイヤのリテラル revert がテストをすり抜けるのと同じ盲点）
+
+### SwiftData の取り扱い
+
+- ⚠️ **autosave footgun**: SwiftUI の `.modelContainer(_:)` は `mainContext.autosaveEnabled = true` がデフォルト。`fetchSettings()` 等で取得した context 追跡下の `@Model` インスタンス（例: `GameSettings`）を `obj.prop = ...` と書き換えると、明示的に save しなくても autosave で**永続化される**
+- そのため、テスト/デバッグ用の一時的な override（例: `--skip-tutorial` で `isFirstLaunch` を無視する）では、**永続モデルを書き換えず**にローカル変数で判定だけ分岐させること。モデルを mutate すると次回の通常起動にも値が残ってバグになる
+- どうしても override 値をモデル経由で渡したい場合は、context 非挿入の detached な `GameSettings()` を作る方式を検討（ただし全フィールド複製の保守コストと、後段で保存経路に乗ると重複 row を作るリスクに注意）
 
 ### View レイヤ修正の検証戦略
 
@@ -95,6 +103,7 @@ app/BubblePopGame/
 - 永続化された GameSettings は SwiftData なので `UserDefaults trick`（`xcrun simctl spawn ... defaults write`）が効かない点に注意
 - 永続化フラグ（`isFirstLaunch` 等）で初期化フローが分岐する場合、手動 walk-through は「初回起動」「2回目以降」の両経路を必ず検証する。Tutorial を経由するかどうかで `updateScreenBounds` のような重要な副作用がスキップされ、本番バグの温床になる
 - `guard` で前提条件を弾く修正を入れるときは、その前提条件を供給するコード（例: `screenBounds` をセットする `onAppear`）が、ガードを通過する全ての到達経路で確実に走るかを必ず洗い出す。コメントに「X で供給される」と書くだけでは、X が一部経路でしか実行されないと永続デッドロックになる
+- ⚠️ **検証後の cleanup を忘れない**: `xcrun simctl launch` でアプリを起動して screenshot を撮ったら、検証完了後に必ず `xcrun simctl terminate <SIM> <BUNDLE>`（必要なら `xcrun simctl shutdown <SIM>`）で停止する。本アプリは BGM がデフォルト ON（`bgmEnabled = true`）でメニュー画面で自動再生されるため、起動しっぱなしにすると裏で音楽が鳴り続ける。**音声を持つアプリの検証では terminate を特に徹底する**
 
 ### UI テスト設計
 

--- a/docs/release-action-plan.md
+++ b/docs/release-action-plan.md
@@ -5,39 +5,42 @@
 - **推定作業量**: 3-5日（1人開発者想定）
 - **作成日**: 2025年9月23日
 
-## 🔴 Phase 1: 致命的バグ修正（優先度：最高 / 1日）
+## 🔴 Phase 1: 致命的バグ修正（優先度：最高 / 1日）✅ 完了（2026-05-29）
 **これらはゲームプレイを破壊する重大な問題です**
 
-### 1. 画面サイズ初期化問題
+> **完了メモ**: 致命的バグ4件は PR #6（Issue #5 PR1）で修正、画面サイズ初期化のデッドロックは
+> PR #10 で追加修正済み。詳細は各項目を参照。
+
+### 1. 画面サイズ初期化問題 ✅ 完了（2026-05-29 / PR #6, #10）
 - **問題**: GameViewModel初期化時に固定screenBoundsでバブル生成（画面外配置リスク）
 - **影響**: ゲーム開始時にバブルが見えない可能性
 - **対応**:
-  - [ ] GameViewModel.swift:19,116 - 遅延初期化実装
-  - [ ] GameView.swift:155 - 実デバイスサイズ反映確認
-  - [ ] 初期化順序の見直し
+  - [x] GameView.swift - 実デバイスサイズ反映確認（PR #6）
+  - [x] 初期化順序の見直し（PR #10: `ContentView.setupDependencies` で生成直後に `updateScreenBounds` を呼び、`startGame()` ガードの `.zero` early-return デッドロックを解消）
+  - 補足: 計画当初の「GameViewModel 遅延初期化」案ではなく、ContentView 初期化時の screenBounds 供給で解決した
 
-### 2. 時間表示不整合
+### 2. 時間表示不整合 ✅ 完了（2026-05-29 / PR #6）
 - **問題**: UIと統計が常に60秒基準（設定変更未反映）
 - **影響**: 設定した時間制限が機能しない
 - **対応**:
-  - [ ] GameView.swift:134 - `gameSettings.gameTime`参照に修正
-  - [ ] GameOverView.swift:102-104 - 実際の制限時間を使用
-  - [ ] 時間バー表示ロジック修正
+  - [x] GameView.swift - `gameSettings.gameTime`参照に修正
+  - [x] GameOverView.swift - 実際の制限時間を使用
+  - [x] 時間バー表示ロジック修正
 
-### 3. ParticleEffectView状態更新問題
+### 3. ParticleEffectView状態更新問題 ✅ 完了（2026-05-29 / PR #6）
 - **問題**: 値型のため状態更新が表示層に反映されない
 - **影響**: パーティクル演出が正しく表示されない
 - **対応**:
-  - [ ] GameView.swift:156 - 参照型ラッパークラス実装
-  - [ ] ParticleEffectView.swift:21-27 - バインディング追加
-  - [ ] EffectServiceとの連携修正
+  - [x] GameView.swift - 参照型ラッパークラス実装
+  - [x] ParticleEffectView.swift - バインディング追加
+  - [x] EffectServiceとの連携修正
 
-### 4. アクセシビリティ無効化
+### 4. アクセシビリティ無効化 ✅ 完了（2026-05-29 / PR #6）
 - **問題**: isHighContrastEnabled常にfalse返却
 - **影響**: 視覚支援機能が動作しない
 - **対応**:
-  - [ ] AccessibilityUtils.swift:131 - UIAccessibility実データ返却
-  - [ ] 高コントラストモードのテスト追加
+  - [x] AccessibilityUtils.swift - UIAccessibility実データ返却
+  - [x] 高コントラストモードのテスト追加
 
 ## 🟠 Phase 2: 機能バグ修正（優先度：高 / 1日）
 **設定やローカライズが正しく動作しない問題**


### PR DESCRIPTION
## 概要
Issue #9 対応。PR #6（致命的バグ4件）+ PR #10（screenBounds 初期化デッドロック）で release-action-plan.md の Phase 1 が実体として完了したため、計画書のチェックボックス・完了日・PR 参照を反映する。あわせて当セッションで得た開発知見を CLAUDE.md に追記する。

## 変更内容
### `docs/release-action-plan.md`（refs #9）
- Phase 1 ヘッダに完了メモ + item 1〜4 のチェックボックスを `[x]` 化
- **item 1（画面サイズ初期化）**: 計画当初の「GameViewModel 遅延初期化」案ではなく、`ContentView.setupDependencies` で生成直後に `updateScreenBounds` を呼ぶ approach（PR #10）で解決した**実態**を注記
- item 2 / 3 / 4: PR #6 で完了

### `CLAUDE.md`（セッションの学び反映）
前セッション分:
- 「View レイヤ修正の検証戦略」拡張: 永続化フラグで初期化フローが分岐する場合の初回/2回目両経路検証、guard 前提条件が全到達経路で供給されるかの確認
- 「UI テスト設計」セクション新設: XCUITest predicate の偽陽性マッチ回避

当セッション分（#7 / #8 対応で得た知見）:
- **MainActor 隔離**: `SWIFT_STRICT_CONCURRENCY=complete` で「通常ビルドでは見えない」Swift 6 conformance 警告の before/after を実測する検証法
- **SwiftData の取り扱い（新設）**: autosave footgun。context 追跡下の `@Model` を mutate すると永続化されるため、debug override は非破壊で行う
- **開発時の注意点**: Xcode 16 file-system synchronized groups（新規ファイルは pbxproj 手編集不要で自動参加）
- **View レイヤ検証戦略**: 検証後の `simctl terminate/shutdown` 徹底（BGM アプリは起動放置で裏で音が鳴り続ける）

## 検証
- ドキュメントのみの変更（コード変更なし）→ ビルド/テスト影響なし
- `APP_STORE_RELEASE_PLAN.md` の "Phase 1" は別物（deployment target / launch screen 等の審査準備タスク）のため本 PR の対象外

## マージ前手動確認
- [ ] release-action-plan.md の Phase 1 記述が実際の修正内容（PR #6 / #10）と一致しているか目視
- [ ] CLAUDE.md の追記内容が正確か（特に SwiftData autosave / strict-concurrency の記述）

Closes #9
refs #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)