### PR TITLE
fix: EffectService protocol を @MainActor 化（Swift 6 対応） (#7)

### DIFF
--- a/app/BubblePopGame/Services/EffectService.swift
+++ b/app/BubblePopGame/Services/EffectService.swift
@@ -9,6 +9,7 @@ import Foundation
 import SwiftUI
 import UIKit
 
+@MainActor
 protocol EffectService {
     func createPopEffect(at position: CGPoint, color: Color)
     func triggerHapticFeedback(intensity: UIImpactFeedbackGenerator.FeedbackStyle)


### PR DESCRIPTION
## 概要
Issue #7 対応。PR #6 で `EffectServiceImpl` を `@MainActor` 化したことで、`EffectService` プロトコル適合時に Swift 6 の `conformance ... crosses into main actor-isolated code` 警告が発生していた。protocol 側にも `@MainActor` を付与し、要件と実装の actor 隔離を一致させる。

## 変更内容
- `app/BubblePopGame/Services/EffectService.swift`: `protocol EffectService` に `@MainActor` を付与（1行追加）

## 検証（before / after を実測）
プロジェクトは `SWIFT_VERSION = 5.0` かつ `SWIFT_STRICT_CONCURRENCY` 未設定（= minimal）のため、**通常ビルドではこの警告は surface しない**。そこで検証用に strict concurrency を有効化して before/after を実測した:

```bash
xcodebuild build ... SWIFT_STRICT_CONCURRENCY=complete
```

- **修正前（baseline）**: `EffectService.swift:21:26: warning: conformance of 'EffectServiceImpl' to protocol 'EffectService' crosses into main actor-isolated code ...` が出ることを確認 ✅
- **修正後**: 同設定で当該警告が**消滅**、error なし ✅
- 唯一の conformer は `EffectServiceImpl`（テスト mock なし）、呼び出し元 `GameViewModel` は既に `@MainActor` のため呼び出し側への影響なし
- `BubblePopGameTests` 全件 PASS（通常 config）

## マージ前手動確認
- [ ] 特になし（コンパイラレベルの actor 隔離整合のみ。挙動変更なし）

## 補足
- DeviceService.swift 等にも別の strict-concurrency 警告が残るが、本 issue の対象外（Swift 6 言語モード切替時に別途対応）

Closes #7
refs #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)