### PR TITLE
feat: DEBUGビルドで --skip-tutorial 起動引数を追加 (#8)

### DIFF
--- a/app/BubblePopGame/ContentView.swift
+++ b/app/BubblePopGame/ContentView.swift
@@ -140,12 +140,19 @@ struct ContentView: View {
         // （GameViewModel.startGame() の guard が .zero で early-return する）
         viewModel.updateScreenBounds(CGRect(origin: .zero, size: screenSize))
 
-        // 初回起動時はチュートリアル、そうでなければメニュー
-        if gameSettings.isFirstLaunch {
-            viewModel.gameState = .tutorial
-        } else {
-            viewModel.gameState = .menu
-        }
+        // 初回起動時はチュートリアル、そうでなければメニュー。
+        // gameSettings は SwiftData で autosave されるため、デバッグの skip 判定で
+        // isFirstLaunch を書き換えると通常起動にも永続化されてしまう。永続モデルは
+        // 変更せず、初期遷移先の判定のみをローカルに決定する。
+        #if DEBUG
+        // デバッグ起動引数 --skip-tutorial でチュートリアルを bypass する（Issue #8）
+        let shouldShowTutorial = gameSettings.isFirstLaunch
+            && !DebugLaunchOptions(arguments: CommandLine.arguments).skipTutorial
+        #else
+        let shouldShowTutorial = gameSettings.isFirstLaunch
+        #endif
+
+        viewModel.gameState = shouldShowTutorial ? .tutorial : .menu
 
         self.gameViewModel = viewModel
     }

--- a/app/BubblePopGame/Utils/DebugLaunchOptions.swift
+++ b/app/BubblePopGame/Utils/DebugLaunchOptions.swift
@@ -1,0 +1,47 @@
+//
+//  DebugLaunchOptions.swift
+//  BubblePopGame
+//
+//  Issue #8: デバッグビルド/UIテスト時に起動引数からテスト用 override を解釈する。
+//
+//  GameSettings は SwiftData で永続化されるため `xcrun simctl spawn ... defaults write`
+//  トリックが効かない。代わりに起動引数で初回起動フローやゲーム設定を bypass し、
+//  メニュー以降の画面検証や UI 自動テストを行えるようにする。
+//
+//  パース処理自体は純粋関数で副作用がないためビルド構成に依存しないが、
+//  実際に override を「適用する」配線は呼び出し側で #if DEBUG ガードすること
+//  （リリースビルドの挙動を変えないため）。
+//
+//  使用例:
+//    xcrun simctl launch <SIM_ID> com.asapapalab.BubblePopGame \
+//      --skip-tutorial --game-time=120 --game-mode=numbered
+//
+
+import Foundation
+
+struct DebugLaunchOptions {
+    /// `--skip-tutorial`: 初回起動でもチュートリアルをスキップしてメニューへ
+    let skipTutorial: Bool
+    /// `--game-time=<秒>`: ゲーム制限時間の override（パース不能なら nil）
+    let gameTime: Double?
+    /// `--game-mode=<モード>`: ゲームモードの override（GameMode の rawValue 文字列）
+    let gameMode: String?
+
+    /// いずれかの override が指定されているか
+    var hasOverrides: Bool {
+        skipTutorial || gameTime != nil || gameMode != nil
+    }
+
+    init(arguments: [String]) {
+        self.skipTutorial = arguments.contains("--skip-tutorial")
+        self.gameTime = Self.value(for: "--game-time=", in: arguments).flatMap(Double.init)
+        self.gameMode = Self.value(for: "--game-mode=", in: arguments)
+    }
+
+    /// `--key=value` 形式の引数から value 部分を取り出す（空文字列は nil 扱い）
+    private static func value(for prefix: String, in arguments: [String]) -> String? {
+        guard let arg = arguments.first(where: { $0.hasPrefix(prefix) }) else { return nil }
+        let value = String(arg.dropFirst(prefix.count))
+        return value.isEmpty ? nil : value
+    }
+}

--- a/app/BubblePopGameTests/DebugLaunchOptionsTests.swift
+++ b/app/BubblePopGameTests/DebugLaunchOptionsTests.swift
@@ -1,0 +1,67 @@
+//
+//  DebugLaunchOptionsTests.swift
+//  BubblePopGameTests
+//
+//  Issue #8: デバッグ起動引数パーサの単体テスト
+//
+
+import Testing
+import Foundation
+@testable import BubblePopGame
+
+@Suite("DebugLaunchOptions パーサ")
+struct DebugLaunchOptionsTests {
+
+    @Test("引数なしでは override なし")
+    func noArguments() {
+        let options = DebugLaunchOptions(arguments: ["/path/to/app"])
+        #expect(options.skipTutorial == false)
+        #expect(options.gameTime == nil)
+        #expect(options.gameMode == nil)
+        #expect(options.hasOverrides == false)
+    }
+
+    @Test("--skip-tutorial を検出する")
+    func skipTutorialFlag() {
+        let options = DebugLaunchOptions(arguments: ["app", "--skip-tutorial"])
+        #expect(options.skipTutorial == true)
+        #expect(options.hasOverrides == true)
+    }
+
+    @Test("--game-time=120 を Double として解釈する")
+    func gameTimeParsing() {
+        let options = DebugLaunchOptions(arguments: ["app", "--game-time=120"])
+        #expect(options.gameTime == 120.0)
+        #expect(options.hasOverrides == true)
+    }
+
+    @Test("--game-time に数値以外を渡すと nil")
+    func gameTimeInvalid() {
+        let options = DebugLaunchOptions(arguments: ["app", "--game-time=abc"])
+        #expect(options.gameTime == nil)
+    }
+
+    @Test("--game-time= が空なら nil")
+    func gameTimeEmpty() {
+        let options = DebugLaunchOptions(arguments: ["app", "--game-time="])
+        #expect(options.gameTime == nil)
+    }
+
+    @Test("--game-mode=numbered を文字列として解釈する")
+    func gameModeParsing() {
+        let options = DebugLaunchOptions(arguments: ["app", "--game-mode=numbered"])
+        #expect(options.gameMode == "numbered")
+        #expect(options.hasOverrides == true)
+    }
+
+    @Test("複数引数を同時に解釈する")
+    func combinedArguments() {
+        let options = DebugLaunchOptions(
+            arguments: ["app", "--skip-tutorial", "--game-time=30", "--game-mode=normal"]
+        )
+        #expect(options.skipTutorial == true)
+        #expect(options.gameTime == 30.0)
+        #expect(options.gameMode == "normal")
+        #expect(options.hasOverrides == true)
+    }
+}


### PR DESCRIPTION
## 概要
Issue #8 対応。`GameSettings.isFirstLaunch` は SwiftData で永続化されるため `xcrun simctl spawn ... defaults write` トリックが効かず、チュートリアル以降の画面検証が全て手動 walk-through 必須だった。起動引数で初回起動フローを bypass できる仕組みを追加する。

## 変更内容
- **`DebugLaunchOptions`（新規）**: 起動引数パーサ。`--skip-tutorial` / `--game-time=<秒>` / `--game-mode=<モード>` を解釈。純粋関数で副作用なし → 単体テスト 7 件で網羅
- **`ContentView.setupDependencies`**: `#if DEBUG` で `--skip-tutorial` を配線
  - ⚠️ `gameSettings` は autosave で永続化されるため、`isFirstLaunch` を**書き換えず**、初期遷移先の判定のみをローカル変数で override（永続状態を汚さない）

## 検証
### 単体テスト
- `DebugLaunchOptionsTests` 全 7 件 PASS（引数なし / skip-tutorial / game-time 正常・異常・空 / game-mode / 複数同時）

### シミュレータ実機検証（before / after）
同一の fresh-install 状態（uninstall → install で SwiftData リセット = `isFirstLaunch=true`）で比較:

| 起動コマンド | 着地画面 | 判定 |
| --- | --- | --- |
| フラグなし | **チュートリアル**（「ようこそ！」） | ✅ 期待通り |
| `--skip-tutorial` | **メニュー**（ゲーム開始/設定/ハイスコア） | ✅ bypass 成功 |

```bash
xcrun simctl launch <SIM_ID> com.asapapalab.BubblePopGame --skip-tutorial
```

### Release ビルド
- `** BUILD SUCCEEDED **`。`#if DEBUG` ガードにより Release 挙動は不変（新規コードの警告なし）

## マージ前手動確認
- [ ] `--skip-tutorial` でメニューに着地する（上記スクショで確認済み、必要なら再現可）
- [ ] フラグなし通常起動の初回フロー（チュートリアル）が変わっていない

## スコープ外（follow-up: #13）
`--game-time` / `--game-mode` はパーサ・テストは完備したが、SwiftData の autosave footgun を避ける非破壊な配線方式の検討が必要なため、本 PR では配線を見送り #13 に切り出した。

Closes #8
refs #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)