### PR TITLE
fix: ローカライズ漏れ修正（HighScore/Pause/Bubble/Tutorial/ContentView） (refs #5)

### DIFF
--- a/app/BubblePopGame/Base.lproj/Localizable.strings
+++ b/app/BubblePopGame/Base.lproj/Localizable.strings
@@ -148,3 +148,16 @@
 "accessibility_bubbles_popped" = "Bubbles popped %d";
 "accessibility_time_remaining" = "Time remaining %d seconds";
 "accessibility_time_warning" = ", time is running low";
+
+// MARK: - Localization fixes (Issue #5)
+"seconds_decimal_format" = "%.1fsec";
+"accessibility_bubble_numbered" = "Bubble with number %d";
+"accessibility_bubble_normal" = "Bubble";
+"accessibility_bubble_hint" = "Tap to pop";
+"accessibility_pause_resume_hint" = "Resume the game";
+"accessibility_pause_quit_hint" = "End the game and return to menu";
+"pause_confirm_exit_title" = "Confirm Game Exit";
+"pause_confirm_exit_message" = "Are you sure you want to quit the game?\nThe current game will be ended.";
+"accessibility_tutorial_skip_hint" = "Skip tutorial and go to menu";
+"loading_settings" = "Loading settings...";
+"loading_initializing" = "Initializing...";

--- a/app/BubblePopGame/ContentView.swift
+++ b/app/BubblePopGame/ContentView.swift
@@ -40,14 +40,14 @@ struct ContentView: View {
                                 }
                             }
                         } else {
-                            ProgressView("設定読み込み中...")
+                            ProgressView(NSLocalizedString("loading_settings", comment: "Loading settings"))
                         }
                     case .highScore:
                         HighScoreView(gameViewModel: gameViewModel)
                     }
                 } else {
                     // 初期化中
-                    ProgressView("初期化中...")
+                    ProgressView(NSLocalizedString("loading_initializing", comment: "Initializing"))
                         .onAppear {
                             setupDependencies(screenSize: geometry.size)
                         }

--- a/app/BubblePopGame/Views/Game/BubbleView.swift
+++ b/app/BubblePopGame/Views/Game/BubbleView.swift
@@ -39,8 +39,10 @@ struct BubbleView: View {
         .animation(.easeOut(duration: 0.3), value: bubble.isPopping)
         .animation(.easeInOut(duration: 3).repeatForever(autoreverses: true), value: bubble.animationPhase)
         .accessibilityElement()
-        .accessibilityLabel(bubble.type == .numbered ? "数字 \(bubble.number ?? 0) のシャボン玉" : "シャボン玉")
-        .accessibilityHint("タップすると破裂します")
+        .accessibilityLabel(bubble.type == .numbered
+            ? String(format: NSLocalizedString("accessibility_bubble_numbered", comment: "Numbered bubble accessibility label"), bubble.number ?? 0)
+            : NSLocalizedString("accessibility_bubble_normal", comment: "Bubble accessibility label"))
+        .accessibilityHint(NSLocalizedString("accessibility_bubble_hint", comment: "Bubble tap hint"))
         .accessibilityAddTraits(.isButton)
     }
 }

--- a/app/BubblePopGame/Views/Game/PauseOverlayView.swift
+++ b/app/BubblePopGame/Views/Game/PauseOverlayView.swift
@@ -39,7 +39,7 @@ struct PauseOverlayView: View {
                     .shadow(radius: 3)
                 }
                 .accessibilityLabel(NSLocalizedString("pause_resume", comment: "Resume accessibility"))
-                .accessibilityHint("Resume the game")
+                .accessibilityHint(NSLocalizedString("accessibility_pause_resume_hint", comment: "Resume hint"))
                 .accessibilityAddTraits(.isButton)
                 
                 // 終了ボタン（2.5秒遅延で表示）
@@ -62,7 +62,7 @@ struct PauseOverlayView: View {
                     }
                     .accessibilityIdentifier("pauseEndButton")
                     .accessibilityLabel(NSLocalizedString("pause_quit", comment: "Quit accessibility"))
-                    .accessibilityHint("End the game and return to menu")
+                    .accessibilityHint(NSLocalizedString("accessibility_pause_quit_hint", comment: "Quit hint"))
                     .accessibilityAddTraits(.isButton)
                     .transition(.opacity.combined(with: .scale))
                 }
@@ -83,7 +83,7 @@ struct PauseOverlayView: View {
             showExitButton = false
             showExitConfirmation = false
         }
-        .alert("Confirm Game Exit", isPresented: $showExitConfirmation) {
+        .alert(NSLocalizedString("pause_confirm_exit_title", comment: "Exit confirmation title"), isPresented: $showExitConfirmation) {
             Button(NSLocalizedString("cancel", comment: "Cancel button"), role: .cancel) {
                 showExitConfirmation = false
             }
@@ -91,7 +91,7 @@ struct PauseOverlayView: View {
                 gameViewModel.endGame()
             }
         } message: {
-            Text("Are you sure you want to quit the game?\nThe current game will be ended.")
+            Text(NSLocalizedString("pause_confirm_exit_message", comment: "Exit confirmation message"))
         }
     }
 }

--- a/app/BubblePopGame/Views/HighScore/HighScoreRow.swift
+++ b/app/BubblePopGame/Views/HighScore/HighScoreRow.swift
@@ -29,7 +29,8 @@ struct HighScoreRow: View {
                     
                     Spacer()
                     
-                    Text(score.gameMode == "numbered" ? "数字順" : "通常")
+                    // 既存の highscore_* キーを再利用
+                    Text(NSLocalizedString(score.gameMode == "numbered" ? "highscore_numbered_mode" : "highscore_normal_mode", comment: "Game mode badge"))
                         .font(.caption)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
@@ -39,25 +40,28 @@ struct HighScoreRow: View {
                 }
                 
                 HStack {
-                    Text("破裂数: \(score.bubblesPopped)")
+                    // ラベルは既存キー（game_bubbles_popped / gameover_accuracy）を再利用し、値を連結
+                    Text("\(NSLocalizedString("game_bubbles_popped", comment: "Bubbles popped label")): \(score.bubblesPopped)")
                         .font(.caption)
                         .foregroundColor(.secondary)
-                    
+
                     Spacer()
-                    
-                    Text("正確率: \(String(format: "%.1f%%", score.accuracy * 100))")
+
+                    Text("\(NSLocalizedString("gameover_accuracy", comment: "Accuracy label")): \(String(format: NSLocalizedString("percentage_format", comment: "Percentage format"), score.accuracy * 100))")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
                 
                 HStack {
-                    Text("制限時間: \(Int(score.gameTimeLimit))秒")
+                    // highscore_time_limit は値に ":" を含むためラベル後はスペース区切り。整数秒は seconds_format
+                    Text("\(NSLocalizedString("highscore_time_limit", comment: "Time limit label (includes colon)")) \(String(format: NSLocalizedString("seconds_format", comment: "Integer seconds format"), Int(score.gameTimeLimit)))")
                         .font(.caption)
                         .foregroundColor(.secondary)
-                    
+
                     Spacer()
-                    
-                    Text("プレイ時間: \(String(format: "%.1f秒", score.gameDuration))")
+
+                    // gameover_play_time ラベル + 小数秒（新規 seconds_decimal_format）
+                    Text("\(NSLocalizedString("gameover_play_time", comment: "Play time label")): \(String(format: NSLocalizedString("seconds_decimal_format", comment: "Decimal seconds format"), score.gameDuration))")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }

--- a/app/BubblePopGame/Views/HighScore/HighScoreView.swift
+++ b/app/BubblePopGame/Views/HighScore/HighScoreView.swift
@@ -41,7 +41,7 @@ struct HighScoreView: View {
                             .font(.headline)
                             .foregroundColor(.primary)
                         
-                        Picker("制限時間", selection: $selectedTimeLimit) {
+                        Picker(NSLocalizedString("settings_time_limit", comment: "Time limit picker label"), selection: $selectedTimeLimit) {
                             ForEach(availableTimeLimits, id: \.self) { timeLimit in
                                 Text(String(format: NSLocalizedString("seconds_format", comment: "Seconds format"), Int(timeLimit))).tag(timeLimit)
                             }

--- a/app/BubblePopGame/Views/TutorialView.swift
+++ b/app/BubblePopGame/Views/TutorialView.swift
@@ -46,7 +46,7 @@ struct TutorialView: View {
                         .background(Color.blue.opacity(0.1))
                         .cornerRadius(8)
                         .accessibilityLabel(NSLocalizedString("skip", comment: "Skip accessibility"))
-                        .accessibilityHint("Skip tutorial and go to menu")
+                        .accessibilityHint(NSLocalizedString("accessibility_tutorial_skip_hint", comment: "Skip tutorial hint"))
                     }
                     .padding(.top, 10)
                     .padding(.horizontal, 20)

--- a/app/BubblePopGame/en.lproj/Localizable.strings
+++ b/app/BubblePopGame/en.lproj/Localizable.strings
@@ -148,3 +148,16 @@
 "accessibility_bubbles_popped" = "Bubbles popped %d";
 "accessibility_time_remaining" = "Time remaining %d seconds";
 "accessibility_time_warning" = ", time is running low";
+
+// MARK: - Localization fixes (Issue #5)
+"seconds_decimal_format" = "%.1fsec";
+"accessibility_bubble_numbered" = "Bubble with number %d";
+"accessibility_bubble_normal" = "Bubble";
+"accessibility_bubble_hint" = "Tap to pop";
+"accessibility_pause_resume_hint" = "Resume the game";
+"accessibility_pause_quit_hint" = "End the game and return to menu";
+"pause_confirm_exit_title" = "Confirm Game Exit";
+"pause_confirm_exit_message" = "Are you sure you want to quit the game?\nThe current game will be ended.";
+"accessibility_tutorial_skip_hint" = "Skip tutorial and go to menu";
+"loading_settings" = "Loading settings...";
+"loading_initializing" = "Initializing...";

--- a/app/BubblePopGame/ja.lproj/Localizable.strings
+++ b/app/BubblePopGame/ja.lproj/Localizable.strings
@@ -148,3 +148,16 @@
 "accessibility_bubbles_popped" = "破裂させたバブル数 %d個";
 "accessibility_time_remaining" = "残り時間 %d秒";
 "accessibility_time_warning" = "、時間が少なくなっています";
+
+// MARK: - Localization fixes (Issue #5)
+"seconds_decimal_format" = "%.1f秒";
+"accessibility_bubble_numbered" = "数字 %d のシャボン玉";
+"accessibility_bubble_normal" = "シャボン玉";
+"accessibility_bubble_hint" = "タップすると破裂します";
+"accessibility_pause_resume_hint" = "ゲームを再開します";
+"accessibility_pause_quit_hint" = "ゲームを終了してメニューに戻ります";
+"pause_confirm_exit_title" = "ゲーム終了の確認";
+"pause_confirm_exit_message" = "本当にゲームを終了しますか？\n現在のゲームは終了されます。";
+"accessibility_tutorial_skip_hint" = "チュートリアルをスキップしてメニューに移動します";
+"loading_settings" = "設定読み込み中...";
+"loading_initializing" = "初期化中...";

--- a/app/BubblePopGameTests/LocalizationKeysTests.swift
+++ b/app/BubblePopGameTests/LocalizationKeysTests.swift
@@ -1,0 +1,84 @@
+//
+//  LocalizationKeysTests.swift
+//  BubblePopGameTests
+//
+//  Issue #5: ローカライズキーの存在とロケール間パリティを保証する回帰テスト。
+//
+//  accessibility 系の文字列（VoiceOver 専用）は ja/en スクリーンショットに映らないため、
+//  キー欠落（= 英語ユーザーに生キー文字列が表示される古典的バグ）が目視検証をすり抜ける。
+//  このテストで「全ロケールに必要キーが存在し、ja/en/Base のキー集合が一致する」ことを
+//  ビルド時に大声で検出する。
+//
+
+import Testing
+import Foundation
+@testable import BubblePopGame
+
+@Suite("ローカライズキーの存在とパリティ")
+struct LocalizationKeysTests {
+
+    /// アプリバンドルを含む型から bundle を解決（テストランナーの Bundle.main ではなくアプリ本体）
+    private var appBundle: Bundle { Bundle(for: GameSettings.self) }
+
+    private func strings(for localization: String) -> [String: String]? {
+        guard let path = appBundle.path(
+            forResource: "Localizable",
+            ofType: "strings",
+            inDirectory: nil,
+            forLocalization: localization
+        ) else { return nil }
+        return NSDictionary(contentsOfFile: path) as? [String: String]
+    }
+
+    /// Issue #5 で新規追加したキー
+    private let newKeys = [
+        "seconds_decimal_format",
+        "accessibility_bubble_numbered",
+        "accessibility_bubble_normal",
+        "accessibility_bubble_hint",
+        "accessibility_pause_resume_hint",
+        "accessibility_pause_quit_hint",
+        "pause_confirm_exit_title",
+        "pause_confirm_exit_message",
+        "accessibility_tutorial_skip_hint",
+        "loading_settings",
+        "loading_initializing",
+    ]
+
+    /// Issue #5 のコード側で再利用している既存キー（将来の削除でビューが壊れるのを防ぐ）
+    private let reusedKeys = [
+        "highscore_numbered_mode",
+        "highscore_normal_mode",
+        "game_bubbles_popped",
+        "gameover_accuracy",
+        "percentage_format",
+        "highscore_time_limit",
+        "seconds_format",
+        "gameover_play_time",
+        "settings_time_limit",
+    ]
+
+    private let localizations = ["ja", "en", "Base"]
+
+    @Test("全ロケールに新規キーと再利用キーが存在する")
+    func requiredKeysExistInAllLocalizations() throws {
+        for loc in localizations {
+            let dict = try #require(strings(for: loc), "\(loc).lproj/Localizable.strings が読み込めない")
+            for key in newKeys + reusedKeys {
+                #expect(dict[key] != nil, "キー '\(key)' が \(loc) に存在しない")
+                // 値が空でないこと（空文字は実質欠落）
+                #expect(dict[key]?.isEmpty == false, "キー '\(key)' の \(loc) 値が空")
+            }
+        }
+    }
+
+    @Test("ja / en / Base のキー集合が一致する（パリティ）")
+    func localizationsHaveIdenticalKeySets() throws {
+        let ja = Set(try #require(strings(for: "ja")).keys)
+        let en = Set(try #require(strings(for: "en")).keys)
+        let base = Set(try #require(strings(for: "Base")).keys)
+
+        #expect(ja == en, "ja と en でキー集合が不一致: ja-only=\(ja.subtracting(en)), en-only=\(en.subtracting(ja))")
+        #expect(en == base, "en と Base でキー集合が不一致: en-only=\(en.subtracting(base)), Base-only=\(base.subtracting(en))")
+    }
+}


### PR DESCRIPTION
## 概要
Issue #5（審査準備＋ローカライゼーション）のアンブレラのうち、**ローカライズ漏れ**部分を対応（release-action-plan.md Phase 2 item6）。ハードコードされた日本語/英語文字列 15 箇所を `Localizable.strings` 化し、リリースブロッカー「ローカライズ完全対応」を前進させる。

> ⚠️ 本プロジェクトのローカライズは旧来の `Localizable.strings`（ja/en/Base lproj）方式。`.xcstrings` ではないため `xcstrings-*` 系の対応は不要。

## 変更内容（15 箇所 / 8→6 ファイル）
| ファイル | 箇所 | 対応 |
| --- | --- | --- |
| HighScoreRow.swift | 5 | mode badge・破裂数・正確率・制限時間・プレイ時間 → 既存キー再利用 + 値連結 |
| HighScoreView.swift | 1 | 制限時間 Picker ラベル → `settings_time_limit` |
| BubbleView.swift | 2 | バブルの accessibilityLabel/Hint（日本語直書き）|
| PauseOverlayView.swift | 4 | accessibilityHint 2件・終了確認 alert title/message（英語直書き）|
| TutorialView.swift | 1 | スキップボタン accessibilityHint（英語直書き）|
| ContentView.swift | 2 | ProgressView ラベル（設定読み込み中/初期化中）|

- 新規キー **11個** を `ja` / `en` / `Base` すべてに追加（パリティ維持）
- 既存キー（`highscore_*` / `game_bubbles_popped` / `gameover_*` 等）を画面横断で再利用（コメントで明記）

## 検証
### 自動
- **`LocalizationKeysTests`（新規）**: 新規11 + 再利用9キーが ja/en/Base **全てに存在** + **キー集合パリティ** + strings ファイルがランタイムでパース可能（malformed なら `NSDictionary(contentsOfFile:)` が nil で失敗）。accessibility 文字列は VoiceOver 専用でスクショに映らないため、この test が欠落を大声で検出する
- ja/en 起動でメニューがロケール切替するスモークテスト（生キー表示なし＝strings 構文無傷を実機確認）

| ja | en |
| --- | --- |
| シャボン玉消しゲーム / ゲーム開始 / 設定 / ハイスコア | Bubble Pop Game / Start Game / Settings / High Score |

### 除外（意図的）
- `SettingsView` の `"0"`/`"100"`（数値スライダーラベル、全ロケール共通でローカライズ不要）
- `LaunchScreenView` の日英併記（大きな日本語タイトル + 小さな英語サブタイトルの意図的ブランディング）

## マージ前手動確認（simctl は no-tap のため要手動 walk-through）
変更文字列の多くは状態依存画面（ハイスコアデータ要 / プレイ中）にあり自動到達不可:
- [ ] **ハイスコア画面**（スコアデータあり）を ja / en で表示し、mode badge・破裂数・正確率・制限時間・プレイ時間が正しく訳出されるか
- [ ] **ポーズ→終了確認ダイアログ**を ja / en で表示し、title/message が訳出されるか
- [ ] VoiceOver でバブル/スキップボタンの読み上げが ja / en で正しいか

refs #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)