### PR TITLE
feat: DEBUG起動引数 --game-time / --game-mode を配線 (#13)

### DIFF
--- a/app/BubblePopGame/ContentView.swift
+++ b/app/BubblePopGame/ContentView.swift
@@ -141,13 +141,19 @@ struct ContentView: View {
         viewModel.updateScreenBounds(CGRect(origin: .zero, size: screenSize))
 
         // 初回起動時はチュートリアル、そうでなければメニュー。
-        // gameSettings は SwiftData で autosave されるため、デバッグの skip 判定で
-        // isFirstLaunch を書き換えると通常起動にも永続化されてしまう。永続モデルは
-        // 変更せず、初期遷移先の判定のみをローカルに決定する。
+        // gameSettings は SwiftData で autosave されるため、デバッグ override で
+        // モデルを書き換えると通常起動にも永続化されてしまう。永続モデルは変更せず、
+        // 初期遷移先の判定と GameViewModel の実効値 override のみをローカルに決定する。
         #if DEBUG
-        // デバッグ起動引数 --skip-tutorial でチュートリアルを bypass する（Issue #8）
-        let shouldShowTutorial = gameSettings.isFirstLaunch
-            && !DebugLaunchOptions(arguments: CommandLine.arguments).skipTutorial
+        let debugOptions = DebugLaunchOptions(arguments: CommandLine.arguments)
+        // --skip-tutorial: チュートリアルを bypass する（Issue #8）
+        let shouldShowTutorial = gameSettings.isFirstLaunch && !debugOptions.skipTutorial
+        // --game-time / --game-mode: GameViewModel の実効値を override（Issue #13）。
+        // gameSettings は書き換えないので永続化されない。
+        viewModel.debugGameTimeOverride = debugOptions.gameTime
+        if let mode = debugOptions.gameMode, GameMode(rawValue: mode) != nil {
+            viewModel.debugGameModeOverride = mode
+        }
         #else
         let shouldShowTutorial = gameSettings.isFirstLaunch
         #endif

--- a/app/BubblePopGame/ViewModels/GameViewModel.swift
+++ b/app/BubblePopGame/ViewModels/GameViewModel.swift
@@ -55,7 +55,33 @@ class GameViewModel {
     private nonisolated(unsafe) var displayLink: CADisplayLink?
     private nonisolated(unsafe) var gameTimer: Timer?
     var gameSettings: GameSettings
-    
+
+    #if DEBUG
+    /// デバッグ起動引数による override（Issue #13）。nil なら gameSettings の値を使う。
+    /// 永続化された gameSettings を書き換えず（autosave で残ってしまうため）、実効値だけを差し替える。
+    var debugGameTimeOverride: Double?
+    var debugGameModeOverride: String?
+    #endif
+
+    /// 実効ゲーム制限時間。DEBUG override があればそれを優先（テスト容易性のため internal）。
+    /// Release では gameSettings.gameTime に collapse する。
+    var effectiveGameTime: Double {
+        #if DEBUG
+        return debugGameTimeOverride ?? gameSettings.gameTime
+        #else
+        return gameSettings.gameTime
+        #endif
+    }
+
+    /// 実効ゲームモード。DEBUG override があればそれを優先（テスト容易性のため internal）。
+    var effectiveGameMode: String {
+        #if DEBUG
+        return debugGameModeOverride ?? gameSettings.gameMode
+        #else
+        return gameSettings.gameMode
+        #endif
+    }
+
     // タッチ応答性監視
     private var lastTouchTime: CFTimeInterval = 0
     private var touchResponseTimes: [CFTimeInterval] = []
@@ -122,7 +148,7 @@ class GameViewModel {
 
         gameState = .playing
         score = 0
-        timeRemaining = gameSettings.gameTime
+        timeRemaining = effectiveGameTime
         bubblesPopped = 0
         currentStreak = 0
         bestStreak = 0
@@ -132,7 +158,7 @@ class GameViewModel {
         successfulTaps = 0
         
         // 数字順ゲームモード初期化
-        if gameSettings.gameMode == "numbered" {
+        if effectiveGameMode == "numbered" {
             // 動的難易度システム初期化
             currentLevel = 1
             levelStartTime = 0.0
@@ -217,7 +243,7 @@ class GameViewModel {
             successfulTaps += 1
             
             // 数字順ゲームモードでの順序チェック
-            if gameSettings.gameMode == "numbered" && hitBubble.type == .numbered {
+            if effectiveGameMode == "numbered" && hitBubble.type == .numbered {
                 if let bubbleNumber = hitBubble.number {
                     if bubbleNumber == nextExpectedNumber {
                         // 正しい順序
@@ -353,7 +379,7 @@ class GameViewModel {
     }
     
     private func generateBubbles() {
-        if gameSettings.gameMode == "numbered" {
+        if effectiveGameMode == "numbered" {
             // 動的システム：カスタム数字セットを使用
             bubbles = bubbleService.generateNumberedBubblesWithCustomSet(
                 count: gameSettings.bubbleCount,
@@ -414,7 +440,7 @@ class GameViewModel {
         // プログレッシブ難易度が無効の場合は常にレベル1
         guard gameSettings.numberedModeProgressive else { return 1 }
         
-        let elapsedTime = gameSettings.gameTime - timeRemaining
+        let elapsedTime = effectiveGameTime - timeRemaining
         let levelInterval = gameSettings.numberedModeLevelInterval
         let maxLevel = gameSettings.numberedModeMaxLevel
         
@@ -489,7 +515,7 @@ class GameViewModel {
         if newLevel != currentLevel {
             // レベルアップ処理
             currentLevel = newLevel
-            levelStartTime = gameSettings.gameTime - timeRemaining
+            levelStartTime = effectiveGameTime - timeRemaining
             currentNumberSet = generateRandomNumberSet(for: currentLevel)
             currentNumberIndex = 0
             nextExpectedNumber = currentNumberSet[0]
@@ -606,10 +632,10 @@ class GameViewModel {
             score: score,
             bubblesPopped: bubblesPopped,
             accuracy: calculateAccuracy(),
-            gameMode: gameSettings.gameMode,
+            gameMode: effectiveGameMode,
             playDate: Date(),
-            gameDuration: gameSettings.gameTime - timeRemaining,
-            gameTimeLimit: gameSettings.gameTime
+            gameDuration: effectiveGameTime - timeRemaining,
+            gameTimeLimit: effectiveGameTime
         )
         
         do {

--- a/app/BubblePopGameTests/DebugOverrideTests.swift
+++ b/app/BubblePopGameTests/DebugOverrideTests.swift
@@ -1,0 +1,79 @@
+//
+//  DebugOverrideTests.swift
+//  BubblePopGameTests
+//
+//  Issue #13: デバッグ起動引数による gameTime / gameMode override の単体テスト。
+//  永続 gameSettings を変更せず、effectiveGameTime / effectiveGameMode で実効値を
+//  差し替える設計を検証する。
+//
+
+import Testing
+import SwiftData
+import Foundation
+@testable import BubblePopGame
+
+@MainActor
+@Suite("DEBUG override (game-time / game-mode)")
+struct DebugOverrideTests {
+
+    static func makeContainer() throws -> ModelContainer {
+        let schema = Schema([GameScore.self, GameStatistics.self, GameSettings.self])
+        return try ModelContainer(
+            for: schema,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    static func makeViewModel(gameTime: Double = 60, gameMode: String = "normal") throws -> GameViewModel {
+        let container = try makeContainer()
+        let settings = GameSettings()
+        settings.gameTime = gameTime
+        settings.gameMode = gameMode
+        return GameViewModel(
+            bubbleService: BubbleServiceImpl(screenBounds: .zero),
+            audioService: AudioServiceImpl(),
+            effectService: EffectServiceImpl(),
+            deviceService: DeviceServiceImpl(),
+            performanceService: PerformanceServiceImpl(),
+            scoreRepository: ScoreRepositoryImpl(modelContainer: container),
+            settingsRepository: SettingsRepositoryImpl(modelContainer: container),
+            statisticsRepository: StatisticsRepositoryImpl(modelContainer: container),
+            gameSettings: settings
+        )
+    }
+
+    @Test("override 未設定なら gameSettings の値にフォールバックする")
+    func fallsBackToSettingsWhenNoOverride() throws {
+        let vm = try Self.makeViewModel(gameTime: 60, gameMode: "normal")
+        #expect(vm.effectiveGameTime == 60)
+        #expect(vm.effectiveGameMode == "normal")
+    }
+
+    @Test("debugGameTimeOverride が effectiveGameTime に反映される")
+    func gameTimeOverrideApplies() throws {
+        let vm = try Self.makeViewModel(gameTime: 60)
+        vm.debugGameTimeOverride = 30
+        #expect(vm.effectiveGameTime == 30)
+        // 永続モデルは変更されないこと
+        #expect(vm.gameSettings.gameTime == 60)
+    }
+
+    @Test("debugGameModeOverride が effectiveGameMode に反映される")
+    func gameModeOverrideApplies() throws {
+        let vm = try Self.makeViewModel(gameMode: "normal")
+        vm.debugGameModeOverride = "numbered"
+        #expect(vm.effectiveGameMode == "numbered")
+        // 永続モデルは変更されないこと
+        #expect(vm.gameSettings.gameMode == "normal")
+    }
+
+    @Test("startGame の timeRemaining が override 値で初期化される（実効値が read される）")
+    func startGameUsesOverriddenTime() throws {
+        let vm = try Self.makeViewModel(gameTime: 60)
+        vm.debugGameTimeOverride = 30
+        vm.updateScreenBounds(CGRect(x: 0, y: 0, width: 400, height: 800))
+        vm.startGame()
+        #expect(vm.timeRemaining == 30,
+                "startGame は effectiveGameTime を read するため override が反映される")
+    }
+}


### PR DESCRIPTION
## 概要
Issue #13 対応（#8 の続き）。#8 で追加した `DebugLaunchOptions` パーサの `--game-time` / `--game-mode` を実際にゲームへ反映する。

### 設計判断: なぜ detached copy ではなく実効値 override か
当初案の「context 非挿入の `GameSettings` を複製して override」は不採用。理由:
- `GameViewModel.saveGameSettings()`（L670）が `TutorialView` から呼ばれており、detached なオブジェクトを保存経路に乗せると**重複 row / 永続化**のリスク
- `GameSettings` は 23 フィールドあり複製の保守コストが高い

代わりに **GameViewModel に実効値 computed property を導入**（永続モデルを一切変更しない）:
- testability が高い（override をセットして effective\* をアサート、#8 パーサと同じ pure-and-tested 形）
- context-wide な副作用ゼロ
- Release では `return gameSettings.gameTime` に collapse（挙動・パフォーマンス不変）

## 変更内容
- **GameViewModel**:
  - `#if DEBUG` の `debugGameTimeOverride` / `debugGameModeOverride` プロパティ
  - `effectiveGameTime` / `effectiveGameMode` computed property（override 優先、なければ gameSettings）
  - `gameSettings.gameTime`/`gameMode` の **read サイト9箇所**（startGame の timeRemaining 初期化 / 順序チェック / バブル生成 / レベル計算 / **スコア記録 gameTimeLimit・gameDuration・gameMode**）を `effective*` に置換。`reloadGameSettings` の書き込みは非対象
- **ContentView**: `#if DEBUG` で `DebugLaunchOptions` を1回パースし、`--game-time` → `debugGameTimeOverride`、`--game-mode` →（`GameMode(rawValue:)` 検証後）`debugGameModeOverride` に設定。`--skip-tutorial`（#8）も同じ debugOptions から判定

## 検証
### 自動
- **`DebugOverrideTests`（新規, 全4件 PASS）**: フォールバック / game-time override / game-mode override / `startGame` 後の `timeRemaining` が override 値（= 実効値が実際に read される証明）。override 時も `gameSettings` が変更されないことも assert
- **全 `BubblePopGameTests` PASS**: 9箇所置換の回帰なし。既存の override なし startGame テスト（`startGameInitializesTimeRemainingFromSettings30/120`）も通過 = フォールバック正常
- **Release ビルド成功**: 新規コード由来の警告なし（effective\* がクリーンに collapse）

### マージ前手動確認（simctl は no-tap = ゲーム画面到達に Start タップが必要なため要手動）
- [ ] `xcrun simctl launch <SIM> com.asapapalab.BubblePopGame --game-time=30` → メニューから「ゲーム開始」タップ → タイマーが **30 秒**から開始
- [ ] `--game-mode=numbered` → 数字順モードで開始
- [ ] 上記デバッグ起動の後、**引数なしで通常起動**して設定が永続化されていない（gameTime/gameMode が元のまま）ことを確認

Closes #13
refs #5, #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)