### PR TITLE
fix: バブルサイズ・速度に GameSettings を反映 (#17)

### DIFF
--- a/app/BubblePopGame/Services/BubbleService.swift
+++ b/app/BubblePopGame/Services/BubbleService.swift
@@ -40,8 +40,12 @@ class BubbleServiceImpl: BubbleService {
     }
 
     func updateBubbleConfig(minRadius: Double, maxRadius: Double, animationSpeed: Double) {
-        self.minRadius = CGFloat(minRadius)
-        self.maxRadius = CGFloat(maxRadius)
+        // min/max が逆転していても CGFloat.random(in:) が trap しないよう正規化する。
+        // （将来 UI でスライダー追加や永続値破損があっても安全に倒す保険）
+        let lo = Swift.min(minRadius, maxRadius)
+        let hi = Swift.max(minRadius, maxRadius)
+        self.minRadius = CGFloat(lo)
+        self.maxRadius = CGFloat(hi)
         self.animationSpeed = CGFloat(animationSpeed)
     }
     

--- a/app/BubblePopGame/Services/BubbleService.swift
+++ b/app/BubblePopGame/Services/BubbleService.swift
@@ -18,41 +18,54 @@ protocol BubbleService {
     func generateNumberedBubbles(count: Int, screenBounds: CGRect, numberedCount: Int) -> [Bubble]
     func generateNumberedBubblesWithCustomSet(count: Int, screenBounds: CGRect, numberSet: [Int]) -> [Bubble]
     func updateScreenBounds(_ bounds: CGRect)
+    func updateBubbleConfig(minRadius: Double, maxRadius: Double, animationSpeed: Double)
 }
 
 class BubbleServiceImpl: BubbleService {
     private var screenBounds: CGRect
     private var bubblePool: [Bubble] = []
-    
+
+    // GameSettings から反映されるバブル生成パラメータ（Issue #17）。
+    // デフォルトは GameSettings のデフォルト値（30/60/1.0）に揃える。
+    private var minRadius: CGFloat = 30.0
+    private var maxRadius: CGFloat = 60.0
+    private var animationSpeed: CGFloat = 1.0
+
     init(screenBounds: CGRect) {
         self.screenBounds = screenBounds
     }
-    
+
     func updateScreenBounds(_ bounds: CGRect) {
         screenBounds = bounds
     }
+
+    func updateBubbleConfig(minRadius: Double, maxRadius: Double, animationSpeed: Double) {
+        self.minRadius = CGFloat(minRadius)
+        self.maxRadius = CGFloat(maxRadius)
+        self.animationSpeed = CGFloat(animationSpeed)
+    }
     
     func createBubble(at position: CGPoint, type: BubbleType) -> Bubble {
-        // 数字タイプは少し大きめに、通常タイプは少し小さめに
-        let radius: CGFloat = type == .numbered ? 
-            CGFloat.random(in: 40...70) : 
-            CGFloat.random(in: 25...50)
-        
+        // 半径は設定値（minRadius/maxRadius）を反映。数字タイプは目立たせるため maxRadius 固定。
+        let radius: CGFloat = type == .numbered ?
+            maxRadius :
+            CGFloat.random(in: minRadius...maxRadius)
+
         // 数字タイプは赤や黄色で目立つように
-        let color: Color = type == .numbered ? 
+        let color: Color = type == .numbered ?
             [.red, .yellow, .orange].randomElement() ?? .red :
             Color.random()
-        
-        // 初期速度もタイプによって少し変える
-        let velocityRange: Range<Double> = type == .numbered ? 
-            -30.0..<30.0 : 
+
+        // 初期速度もタイプによって少し変える（animationSpeed でスケール）
+        let velocityRange: Range<Double> = type == .numbered ?
+            -30.0..<30.0 :
             -50.0..<50.0
-        
+
         return Bubble(
             position: position,
             velocity: CGVector(
-                dx: Double.random(in: velocityRange), 
-                dy: Double.random(in: velocityRange)
+                dx: Double.random(in: velocityRange) * Double(animationSpeed),
+                dy: Double.random(in: velocityRange) * Double(animationSpeed)
             ),
             radius: radius,
             type: type,
@@ -64,14 +77,14 @@ class BubbleServiceImpl: BubbleService {
     }
     
     func createNumberedBubble(at position: CGPoint, number: Int) -> Bubble {
-        let radius: CGFloat = 50.0 // 数字バブルは固定サイズ
+        let radius: CGFloat = maxRadius // 数字バブルは目立たせるため maxRadius で固定
         let color: Color = .yellow // 数字バブルは黄色で統一
-        
+
         return Bubble(
             position: position,
             velocity: CGVector(
-                dx: Double.random(in: -20.0..<20.0), 
-                dy: Double.random(in: -20.0..<20.0)
+                dx: Double.random(in: -20.0..<20.0) * Double(animationSpeed),
+                dy: Double.random(in: -20.0..<20.0) * Double(animationSpeed)
             ),
             radius: radius,
             type: .numbered,

--- a/app/BubblePopGame/ViewModels/GameViewModel.swift
+++ b/app/BubblePopGame/ViewModels/GameViewModel.swift
@@ -379,6 +379,15 @@ class GameViewModel {
     }
     
     private func generateBubbles() {
+        // 設定値（バブルサイズ・速度）をサービスへ反映（Issue #17）。
+        // ここで毎ゲーム開始時に push することで、設定変更が次ゲームに確実に反映され、
+        // プレイ中の addRandomBubble(createBubble) にも効く。
+        bubbleService.updateBubbleConfig(
+            minRadius: gameSettings.bubbleMinRadius,
+            maxRadius: gameSettings.bubbleMaxRadius,
+            animationSpeed: gameSettings.animationSpeed
+        )
+
         if effectiveGameMode == "numbered" {
             // 動的システム：カスタム数字セットを使用
             bubbles = bubbleService.generateNumberedBubblesWithCustomSet(

--- a/app/BubblePopGameTests/BubbleServiceTests.swift
+++ b/app/BubblePopGameTests/BubbleServiceTests.swift
@@ -279,6 +279,23 @@ struct BubbleServiceTests {
         #expect(bubble.radius == 15.0)
     }
 
+    @Test("min/max が逆転していてもクラッシュせず範囲内に収まる")
+    func testInvertedRadiusConfigDoesNotCrash() {
+        let service = createTestService()
+        // 逆転した値を渡しても random(in:) が trap しないこと（正規化される）
+        service.updateBubbleConfig(minRadius: 60.0, maxRadius: 30.0, animationSpeed: 1.0)
+
+        for _ in 0..<50 {
+            let bubble = service.createBubble(at: CGPoint(x: 100, y: 100), type: .normal)
+            #expect(bubble.radius >= 30.0)
+            #expect(bubble.radius <= 60.0)
+        }
+
+        // 数字バブルは大きい方（60）で固定
+        let numbered = service.createNumberedBubble(at: CGPoint(x: 100, y: 100), number: 1)
+        #expect(numbered.radius == 60.0)
+    }
+
     @Test("animationSpeed が初期速度をスケールする")
     func testAnimationSpeedScalesVelocity() {
         let service = createTestService()

--- a/app/BubblePopGameTests/BubbleServiceTests.swift
+++ b/app/BubblePopGameTests/BubbleServiceTests.swift
@@ -28,18 +28,19 @@ struct BubbleServiceTests {
         #expect(normalBubble.position.y == position.y)
         #expect(normalBubble.type == .normal)
         #expect(normalBubble.number == nil)
-        #expect(normalBubble.radius >= 25.0)
-        #expect(normalBubble.radius <= 50.0)
+        // 設定未指定時はデフォルト（GameSettings 既定の min=30/max=60）を反映
+        #expect(normalBubble.radius >= 30.0)
+        #expect(normalBubble.radius <= 60.0)
         #expect(normalBubble.alpha == 0.8)
         #expect(normalBubble.isPopping == false)
-        
-        // 数字付きバブル作成
+
+        // 数字付きバブル作成（デフォルト maxRadius=60 で固定）
         let numberedBubble = service.createNumberedBubble(at: position, number: 5)
         #expect(numberedBubble.position.x == position.x)
         #expect(numberedBubble.position.y == position.y)
         #expect(numberedBubble.type == .numbered)
         #expect(numberedBubble.number == 5)
-        #expect(numberedBubble.radius == 50.0)
+        #expect(numberedBubble.radius == 60.0)
     }
     
     @Test("衝突判定の正確性テスト")
@@ -255,6 +256,44 @@ struct BubbleServiceTests {
         #expect(colors.count >= 1)
     }
     
+    @Test("バブル半径が設定の min/max を反映する")
+    func testBubbleRadiusReflectsSettings() {
+        let service = createTestService()
+        service.updateBubbleConfig(minRadius: 10.0, maxRadius: 15.0, animationSpeed: 1.0)
+
+        // 設定した半径範囲内で生成されることを確認（ランダムなので複数回）
+        for _ in 0..<50 {
+            let bubble = service.createBubble(at: CGPoint(x: 100, y: 100), type: .normal)
+            #expect(bubble.radius >= 10.0)
+            #expect(bubble.radius <= 15.0)
+        }
+    }
+
+    @Test("数字バブル半径が設定の maxRadius を反映する")
+    func testNumberedBubbleRadiusReflectsSettings() {
+        let service = createTestService()
+        service.updateBubbleConfig(minRadius: 10.0, maxRadius: 15.0, animationSpeed: 1.0)
+
+        // 数字バブルは目立たせるため maxRadius で固定生成
+        let bubble = service.createNumberedBubble(at: CGPoint(x: 100, y: 100), number: 3)
+        #expect(bubble.radius == 15.0)
+    }
+
+    @Test("animationSpeed が初期速度をスケールする")
+    func testAnimationSpeedScalesVelocity() {
+        let service = createTestService()
+        // animationSpeed=0 なら初速も0になる（決定的に検証可能）
+        service.updateBubbleConfig(minRadius: 30.0, maxRadius: 60.0, animationSpeed: 0.0)
+
+        let normalBubble = service.createBubble(at: CGPoint(x: 100, y: 100), type: .normal)
+        #expect(normalBubble.velocity.dx == 0.0)
+        #expect(normalBubble.velocity.dy == 0.0)
+
+        let numberedBubble = service.createNumberedBubble(at: CGPoint(x: 100, y: 100), number: 1)
+        #expect(numberedBubble.velocity.dx == 0.0)
+        #expect(numberedBubble.velocity.dy == 0.0)
+    }
+
     @Test("境界跳ね返り処理テスト")
     func testBoundaryBounceLogic() {
         let service = createTestService()

--- a/app/BubblePopGameTests/SettingsReflectionTests.swift
+++ b/app/BubblePopGameTests/SettingsReflectionTests.swift
@@ -1,0 +1,110 @@
+//
+//  SettingsReflectionTests.swift
+//  BubblePopGameTests
+//
+//  Issue #17: 設定値（バブルサイズ・速度）が BubbleService に反映されることの回帰テスト
+//
+
+import Testing
+import SwiftData
+import Foundation
+import SwiftUI
+@testable import BubblePopGame
+
+/// updateBubbleConfig の呼び出しを記録し、生成系メソッドは実装へ委譲する spy。
+/// 「設定をサービスへ push する supply line」が将来 silent revert されても
+/// 検知できるようにするためのテスト用ダブル。
+final class SpyBubbleService: BubbleService {
+    private let wrapped: BubbleServiceImpl
+    private(set) var updateBubbleConfigCallCount = 0
+    private(set) var lastConfig: (minRadius: Double, maxRadius: Double, animationSpeed: Double)?
+
+    init(screenBounds: CGRect) {
+        wrapped = BubbleServiceImpl(screenBounds: screenBounds)
+    }
+
+    func createBubble(at position: CGPoint, type: BubbleType) -> Bubble {
+        wrapped.createBubble(at: position, type: type)
+    }
+    func createNumberedBubble(at position: CGPoint, number: Int) -> Bubble {
+        wrapped.createNumberedBubble(at: position, number: number)
+    }
+    func updateBubbles(_ bubbles: inout [Bubble]) {
+        wrapped.updateBubbles(&bubbles)
+    }
+    func checkCollision(at point: CGPoint, in bubbles: [Bubble]) -> Bubble? {
+        wrapped.checkCollision(at: point, in: bubbles)
+    }
+    func checkCollisionIndex(at point: CGPoint, in bubbles: [Bubble]) -> Int {
+        wrapped.checkCollisionIndex(at: point, in: bubbles)
+    }
+    func generateRandomBubbles(count: Int, screenBounds: CGRect) -> [Bubble] {
+        wrapped.generateRandomBubbles(count: count, screenBounds: screenBounds)
+    }
+    func generateNumberedBubbles(count: Int, screenBounds: CGRect, numberedCount: Int) -> [Bubble] {
+        wrapped.generateNumberedBubbles(count: count, screenBounds: screenBounds, numberedCount: numberedCount)
+    }
+    func generateNumberedBubblesWithCustomSet(count: Int, screenBounds: CGRect, numberSet: [Int]) -> [Bubble] {
+        wrapped.generateNumberedBubblesWithCustomSet(count: count, screenBounds: screenBounds, numberSet: numberSet)
+    }
+    func updateScreenBounds(_ bounds: CGRect) {
+        wrapped.updateScreenBounds(bounds)
+    }
+    func updateBubbleConfig(minRadius: Double, maxRadius: Double, animationSpeed: Double) {
+        updateBubbleConfigCallCount += 1
+        lastConfig = (minRadius, maxRadius, animationSpeed)
+        wrapped.updateBubbleConfig(minRadius: minRadius, maxRadius: maxRadius, animationSpeed: animationSpeed)
+    }
+}
+
+@MainActor
+@Suite("設定値反映 (Issue #17)")
+struct SettingsReflectionTests {
+
+    static func makeContainer() throws -> ModelContainer {
+        let schema = Schema([
+            GameScore.self,
+            GameStatistics.self,
+            GameSettings.self,
+        ])
+        return try ModelContainer(
+            for: schema,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    @Test("startGame で BubbleService に GameSettings のバブル設定が push される")
+    func startGamePushesSettingsToBubbleService() throws {
+        let container = try Self.makeContainer()
+        let settings = GameSettings()
+        settings.bubbleMinRadius = 22.0
+        settings.bubbleMaxRadius = 44.0
+        settings.animationSpeed = 1.5
+        settings.bgmEnabled = false // テスト中の BGM 再生を避ける
+
+        let spy = SpyBubbleService(screenBounds: .zero)
+        let vm = GameViewModel(
+            bubbleService: spy,
+            audioService: AudioServiceImpl(),
+            effectService: EffectServiceImpl(),
+            deviceService: DeviceServiceImpl(),
+            performanceService: PerformanceServiceImpl(),
+            scoreRepository: ScoreRepositoryImpl(modelContainer: container),
+            settingsRepository: SettingsRepositoryImpl(modelContainer: container),
+            statisticsRepository: StatisticsRepositoryImpl(modelContainer: container),
+            gameSettings: settings
+        )
+
+        // startGame は screenBounds=.zero だとバブル生成を遅延するため、先に実サイズを設定
+        vm.updateScreenBounds(CGRect(x: 0, y: 0, width: 400, height: 800))
+        vm.startGame()
+
+        #expect(spy.updateBubbleConfigCallCount >= 1)
+        #expect(spy.lastConfig?.minRadius == 22.0)
+        #expect(spy.lastConfig?.maxRadius == 44.0)
+        #expect(spy.lastConfig?.animationSpeed == 1.5)
+
+        // タイマー/ゲームループを止めてテスト後に残さない
+        vm.pauseGame()
+    }
+}


### PR DESCRIPTION
## 概要
`docs/release-action-plan.md` Phase 2 #5「設定値未反映」を修正。BubbleService がバブル半径を固定値で生成しており、設定画面の `bubbleMinRadius` / `bubbleMaxRadius` / `animationSpeed` がゲームに反映されない機能バグを解消する。

Closes #17 / refs #5

## 変更点
- `BubbleService` に `updateBubbleConfig(minRadius:maxRadius:animationSpeed:)` を追加
  - SwiftData `@Model`（GameSettings）を渡さずプレーン値で受け、Service 層を設定モデルから疎結合に保つ（#20 の DI 改善方針とも整合）
- `createBubble` / `createNumberedBubble` が設定値を参照
  - normal: `random(minRadius...maxRadius)`
  - numbered: `maxRadius` 固定（目立たせる意図を維持）
  - 初速を `animationSpeed` でスケール
- `GameViewModel.generateBubbles()` 冒頭で毎ゲーム開始時に設定を push
  - 設定変更が次ゲームに確実に反映され、プレイ中の `addRandomBubble(createBubble)` にも効く

## テスト
TDD（失敗テスト先行 → 実装）:
- ✅ `testBubbleRadiusReflectsSettings` — 設定 min/max 範囲内で生成
- ✅ `testNumberedBubbleRadiusReflectsSettings` — 数字バブルは maxRadius
- ✅ `testAnimationSpeedScalesVelocity` — animationSpeed=0 で初速0（決定的検証）
- ✅ 既存 `testBubbleCreation` を新デフォルト契約(30/60)に更新
- ✅ `BubblePopGameTests` 全体グリーン

```
xcodebuild test ... -only-testing:BubblePopGameTests → ** TEST SUCCEEDED **
```

## マージ前 手動確認チェックリスト
> Service/ViewModel 層の変更だがユーザー可視効果はゲーム内。`simctl` にタップが無く設定変更フローは自動検証不可のため、レビュア手動確認推奨。

- [ ] 設定画面でバブルサイズ（min/max）を変更 → ゲーム開始でバブルの大きさが変わる
- [ ] 設定画面で animationSpeed を変更 → バブルの移動速度が変わる
- [ ] デフォルト設定（30/60/1.0）で従来同等のプレイ感
- [ ] 数字モードでも数字バブルが maxRadius で表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)
