### PR TITLE
feat: LaunchScreen のローカライズ仕上げ＋英語重複解消 (#18)

### DIFF
--- a/app/BubblePopGame/Base.lproj/Localizable.strings
+++ b/app/BubblePopGame/Base.lproj/Localizable.strings
@@ -14,6 +14,7 @@
 
 // MARK: - Menu Screen
 "game_title" = "Bubble Pop Game";
+"launch_subtitle" = "";
 "menu_start_game" = "Start Game";
 "menu_settings" = "Settings";
 "menu_high_score" = "High Score";

--- a/app/BubblePopGame/Views/LaunchScreenView.swift
+++ b/app/BubblePopGame/Views/LaunchScreenView.swift
@@ -65,15 +65,21 @@ struct LaunchScreenView: View {
                     
                     // アプリ名
                     VStack(spacing: 8) {
-                        Text("シャボン玉消しゲーム")
+                        Text(NSLocalizedString("game_title", comment: "Game title"))
                             .font(.largeTitle)
                             .fontWeight(.bold)
                             .foregroundColor(.white)
                             .multilineTextAlignment(.center)
-                        
-                        Text("Bubble Pop Game")
-                            .font(.title3)
-                            .foregroundColor(.white.opacity(0.8))
+
+                        // ブランド英語名のサブタイトル。日本語ロケールでは日本語タイトルの
+                        // 下に英語名を添える演出。英語ロケールでは game_title と重複するため
+                        // launch_subtitle を空にして非表示にする。
+                        let launchSubtitle = NSLocalizedString("launch_subtitle", comment: "Launch screen subtitle (English brand name); empty in English locale")
+                        if !launchSubtitle.isEmpty {
+                            Text(launchSubtitle)
+                                .font(.title3)
+                                .foregroundColor(.white.opacity(0.8))
+                        }
                     }
                     .opacity(isAnimating ? 1.0 : 0.0)
                     .offset(y: isAnimating ? 0 : 20)

--- a/app/BubblePopGame/en.lproj/Localizable.strings
+++ b/app/BubblePopGame/en.lproj/Localizable.strings
@@ -14,6 +14,7 @@
 
 // MARK: - Menu Screen
 "game_title" = "Bubble Pop Game";
+"launch_subtitle" = "";
 "menu_start_game" = "Start Game";
 "menu_settings" = "Settings";
 "menu_high_score" = "High Score";

--- a/app/BubblePopGame/ja.lproj/Localizable.strings
+++ b/app/BubblePopGame/ja.lproj/Localizable.strings
@@ -14,6 +14,7 @@
 
 // MARK: - Menu Screen
 "game_title" = "シャボン玉消しゲーム";
+"launch_subtitle" = "Bubble Pop Game";
 "menu_start_game" = "ゲーム開始";
 "menu_settings" = "設定";
 "menu_high_score" = "ハイスコア";


### PR DESCRIPTION
## 概要
`docs/release-action-plan.md` Phase 2 #6「ローカライズ漏れ」の仕上げ。PR #15 でカタログは同期済み（ja/en/Base 131キー一致）だったため、残る直書きリテラルの掃除と最終 audit を実施。

Closes #18 / refs #5

## 変更点
- **LaunchScreenView の直書き解消**: `Text("シャボン玉消しゲーム")` → `NSLocalizedString("game_title")`。
  英語ロケールでアプリ名が日本語のまま出る唯一の漏れを修正（MenuView は既に `game_title` を使用済み）。
- **英語サブタイトルの重複解消**: `Text("Bubble Pop Game")` は英語ロケールで `game_title` と重複するため、
  `launch_subtitle` キー（ja=`"Bubble Pop Game"` / en・Base=`""`）を新設し、空でない時のみ表示する条件に変更。
  日本語の「日本語タイトル＋英語ブランド副題」バイリンガル演出は維持。

## 最終 audit 結果
ローカライズはほぼ完成状態だったことを確認:
- ✅ ViewModels / Services のユーザー向け日本語直書き: **なし**
- ✅ アクセシビリティラベル/ヒント: **全て `NSLocalizedString`**（直書きなし）
- ✅ `String(format:)`: 全て `seconds_format` 等のキー経由で localize 済み
- ℹ️ 本プロジェクトは `.strings`（ja/en/Base lproj）方式。`.xcstrings` の plural-variation 等の罠は非該当

## テスト / 検証
- キー parity: **132/132/132**（ja/en/Base 差分なし）
- `LocalizationKeysTests`（キー集合一致・必須キー存在）/ `BubblePopGameTests` 全グリーン
- Simulator ロケール検証（起動画面）:
  - **ja**: 「シャボン玉消しゲーム」＋ 英語副題「Bubble Pop Game」✅
  - **en**: 「Bubble Pop Game」のみ（副題重複なし）✅

## マージ前 手動確認チェックリスト
> View リテラル変更は unit test で捕捉できない盲点のため、レビュア手動確認推奨。

- [ ] 起動画面: 日本語端末で「シャボン玉消しゲーム」＋「Bubble Pop Game」が表示される
- [ ] 起動画面: 英語端末で「Bubble Pop Game」のみ（副題重複なし）
- [ ] メニュー画面のタイトルも各言語で正しい

🤖 Generated with [Claude Code](https://claude.com/claude-code)
