### PR TITLE
docs: 単一テスト -only-testing の0件SUCCEEDED罠を CLAUDE.md に追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ xcodebuild test ... 2>&1 | grep -iE "Suite.*(started|passed|failed)|Test case .*
 ```
 `** TEST SUCCEEDED **` だけ見るとどのテストが走ったか分からないので、テストの実体確認には上記パターン推奨。
 
+⚠️ **単一テスト指定の「0件 SUCCEEDED」罠**: `-only-testing:BubblePopGameTests/SuiteName/testMethod()` のように**メソッド単位**まで絞ると、ビルドキャッシュ等の都合で**1件も実行されないまま `** TEST SUCCEEDED **`**（vacuous）になることがある。これを RED 確認に使うと「落ちるはずのテストが通った」と誤認する。テストを確実に走らせて RED/GREEN を判定したいときは **suite 単位**（`-only-testing:BubblePopGameTests/SuiteName`）で実行し、上の grep で `Test case '...' (passed|failed)` 行が実際に出力されることを確認すること。
+
 ## アーキテクチャ
 
 ### ディレクトリ構造


### PR DESCRIPTION
Issue #5 セッションの振り返りで得た学びを CLAUDE.md に反映。

## 追記内容
SwiftTesting 節に、`-only-testing:Suite/Test/method()` のメソッド単位指定が
**0件実行のまま `** TEST SUCCEEDED **`** になりうる罠を追記。RED 確認は suite 単位で
実行し、`Test case '...' (passed|failed)` 行の出力を確認する旨を明記。

今セッションで実際に踏んだ罠（逆転ガードの RED 確認時、単一テスト指定が vacuous
SUCCEEDED になり、suite 単位で再実行して初めて FAILED を確認できた）。

main から独立した docs-only PR。コード変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)