### PR TITLE
feat: #20 を main へ re-land（DI改善＋パフォーマンス回復）

### DIFF
--- a/app/BubblePopGame/Services/EffectService.swift
+++ b/app/BubblePopGame/Services/EffectService.swift
@@ -16,6 +16,9 @@ protocol EffectService {
     func triggerSuccessFeedback()
     func triggerWarningFeedback()
     func triggerErrorFeedback()
+    /// パーティクル演出用 ViewModel を注入する。
+    /// 具象型へのダウンキャストを避けるため protocol に定義（Issue #20 / DI 改善）。
+    func setParticleEffectViewModel(_ viewModel: ParticleEffectViewModel?)
 }
 
 @MainActor
@@ -27,7 +30,11 @@ class EffectServiceImpl: EffectService {
     private let notificationFeedback: UINotificationFeedbackGenerator
     
     var particleEffectViewModel: ParticleEffectViewModel?
-    
+
+    func setParticleEffectViewModel(_ viewModel: ParticleEffectViewModel?) {
+        particleEffectViewModel = viewModel
+    }
+
     init() {
         self.lightFeedback = UIImpactFeedbackGenerator(style: .light)
         self.mediumFeedback = UIImpactFeedbackGenerator(style: .medium)

--- a/app/BubblePopGame/ViewModels/GameViewModel.swift
+++ b/app/BubblePopGame/ViewModels/GameViewModel.swift
@@ -117,20 +117,32 @@ class GameViewModel {
         bubbleService.updateScreenBounds(bounds)
     }
     
-    // パフォーマンス最適化メソッド
+    // パフォーマンス最適化メソッド。
+    // 負荷に応じてバブル数を目標値へ「削減」「補充」の双方向に調整する（Issue #8）。
+    // 数字モードはバブル集合が 1..N のルール依存のため対象外（補充で .normal を足すと
+    // 数字シーケンスが壊れるため）。
     func optimizePerformance() {
+        guard effectiveGameMode != "numbered" else { return }
+
         let adjustment = performanceService.getPerformanceAdjustment()
         let optimalBubbleCount = Int(Double(gameSettings.bubbleCount) * adjustment)
         let deviceOptimalCount = deviceService.adaptBubbleCount(for: gameSettings)
-        
-        // より制限の厳しい方を採用
+
+        // より制限の厳しい方を採用（finalBubbleCount <= gameSettings.bubbleCount）
         let finalBubbleCount = min(optimalBubbleCount, deviceOptimalCount)
-        
-        // バブル数が現在より少ない場合は調整
+
         if bubbles.count > finalBubbleCount {
+            // 負荷が高い → 余剰を削除
             let excess = bubbles.count - finalBubbleCount
             bubbles.removeLast(excess)
+        } else if bubbles.count < finalBubbleCount {
+            // 負荷が回復 → 目標数まで補充（Issue #8: 回復ロジック）
+            let deficit = finalBubbleCount - bubbles.count
+            for _ in 0..<deficit {
+                addRandomBubble()
+            }
         }
+        // bubbles.count == finalBubbleCount: 定常状態は no-op（毎秒のちらつき防止）
     }
     
     func setupParticleEffectViewModel(_ viewModel: ParticleEffectViewModel) {
@@ -603,11 +615,10 @@ class GameViewModel {
         // 画面境界を越えたシャボン玉を削除
         removeBubblesOutOfBounds()
         
-        // パフォーマンス監視とバブル数の動的調整（60フレームごと＝約1秒）
+        // パフォーマンス監視とバブル数の動的調整（約1秒ごと）。
+        // ungated で呼ぶことで、負荷上昇時の削減だけでなく回復時の補充も行われる（Issue #8）。
         if displayLink?.timestamp.truncatingRemainder(dividingBy: 1.0) ?? 0 < 0.02 {
-            if performanceService.shouldReduceBubbles() {
-                optimizePerformance()
-            }
+            optimizePerformance()
         }
     }
     

--- a/app/BubblePopGame/ViewModels/GameViewModel.swift
+++ b/app/BubblePopGame/ViewModels/GameViewModel.swift
@@ -134,9 +134,8 @@ class GameViewModel {
     }
     
     func setupParticleEffectViewModel(_ viewModel: ParticleEffectViewModel) {
-        if let effectServiceImpl = effectService as? EffectServiceImpl {
-            effectServiceImpl.particleEffectViewModel = viewModel
-        }
+        // 具象型へのダウンキャストを避け、protocol 経由で注入（Issue #20 / DI 改善）。
+        effectService.setParticleEffectViewModel(viewModel)
     }
     
     func startGame() {

--- a/app/BubblePopGameTests/PerformanceAndDITests.swift
+++ b/app/BubblePopGameTests/PerformanceAndDITests.swift
@@ -1,0 +1,78 @@
+//
+//  PerformanceAndDITests.swift
+//  BubblePopGameTests
+//
+//  Issue #20: 依存性注入の具象型キャスト除去（#7）＋ パフォーマンス回復ロジック（#8）
+//
+
+import Testing
+import SwiftData
+import Foundation
+import SwiftUI
+import UIKit
+@testable import BubblePopGame
+
+/// EffectServiceImpl ではない EffectService 実装。
+/// setupParticleEffectViewModel が具象型キャストに依存していると、この spy には
+/// 値がセットされない（= テストが失敗する）ことで DI 違反を検知する。
+@MainActor
+final class SpyEffectService: EffectService {
+    var didCallSetParticleEffectViewModel = false
+    var receivedParticleViewModel: ParticleEffectViewModel?
+
+    func createPopEffect(at position: CGPoint, color: Color) {}
+    func triggerHapticFeedback(intensity: UIImpactFeedbackGenerator.FeedbackStyle) {}
+    func triggerSuccessFeedback() {}
+    func triggerWarningFeedback() {}
+    func triggerErrorFeedback() {}
+    func setParticleEffectViewModel(_ viewModel: ParticleEffectViewModel?) {
+        didCallSetParticleEffectViewModel = true
+        receivedParticleViewModel = viewModel
+    }
+}
+
+@MainActor
+@Suite("DI改善・パフォーマンス回復 (Issue #20)")
+struct PerformanceAndDITests {
+
+    static func makeContainer() throws -> ModelContainer {
+        let schema = Schema([GameScore.self, GameStatistics.self, GameSettings.self])
+        return try ModelContainer(
+            for: schema,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    static func makeViewModel(
+        effect: EffectService,
+        gameMode: String = "normal"
+    ) throws -> GameViewModel {
+        let container = try makeContainer()
+        let settings = GameSettings()
+        settings.gameMode = gameMode
+        settings.bgmEnabled = false
+        return GameViewModel(
+            bubbleService: BubbleServiceImpl(screenBounds: CGRect(x: 0, y: 0, width: 400, height: 800)),
+            audioService: AudioServiceImpl(),
+            effectService: effect,
+            deviceService: DeviceServiceImpl(),
+            performanceService: PerformanceServiceImpl(),
+            scoreRepository: ScoreRepositoryImpl(modelContainer: container),
+            settingsRepository: SettingsRepositoryImpl(modelContainer: container),
+            statisticsRepository: StatisticsRepositoryImpl(modelContainer: container),
+            gameSettings: settings
+        )
+    }
+
+    @Test("setupParticleEffectViewModel は具象型に依存せず protocol 経由で設定する")
+    func setupParticleEffectViewModelUsesProtocol() throws {
+        let spy = SpyEffectService()
+        let vm = try Self.makeViewModel(effect: spy)
+        let particleVM = ParticleEffectViewModel()
+
+        vm.setupParticleEffectViewModel(particleVM)
+
+        #expect(spy.didCallSetParticleEffectViewModel)
+        #expect(spy.receivedParticleViewModel === particleVM)
+    }
+}

--- a/app/BubblePopGameTests/PerformanceAndDITests.swift
+++ b/app/BubblePopGameTests/PerformanceAndDITests.swift
@@ -31,6 +31,29 @@ final class SpyEffectService: EffectService {
     }
 }
 
+/// 調整値を任意に固定できる PerformanceService の fake。
+final class FakePerformanceService: PerformanceService {
+    var adjustment: Double = 1.0
+    var reduce: Bool = false
+    var currentFPS: Double = 60
+    var averageFPS: Double = 60
+    var isPerformanceGood: Bool = true
+    func startMonitoring() {}
+    func stopMonitoring() {}
+    func shouldReduceBubbles() -> Bool { reduce }
+    func getPerformanceAdjustment() -> Double { adjustment }
+}
+
+/// デバイス上限を大きく固定し、finalBubbleCount を adjustment だけで決まるようにする fake。
+final class FakeDeviceService: DeviceService {
+    var deviceType: DeviceType = .iPhone
+    var screenSize: CGSize = CGSize(width: 400, height: 800)
+    var isLowPerformanceDevice: Bool = false
+    var optimalCount: Int = 1000
+    func adaptBubbleCount(for settings: GameSettings) -> Int { optimalCount }
+    func getOptimalBubbleSize() -> CGFloat { 50 }
+}
+
 @MainActor
 @Suite("DI改善・パフォーマンス回復 (Issue #20)")
 struct PerformanceAndDITests {
@@ -74,5 +97,84 @@ struct PerformanceAndDITests {
 
         #expect(spy.didCallSetParticleEffectViewModel)
         #expect(spy.receivedParticleViewModel === particleVM)
+    }
+
+    // MARK: - パフォーマンス回復 (#8)
+
+    static func makePerfViewModel(
+        perf: PerformanceService,
+        device: DeviceService,
+        gameMode: String = "normal"
+    ) throws -> GameViewModel {
+        let container = try makeContainer()
+        let settings = GameSettings()
+        settings.gameMode = gameMode
+        settings.bgmEnabled = false
+        // bubbleCount は既定 20。finalBubbleCount = min(20 * adjustment, deviceOptimal)
+        let vm = GameViewModel(
+            bubbleService: BubbleServiceImpl(screenBounds: CGRect(x: 0, y: 0, width: 400, height: 800)),
+            audioService: AudioServiceImpl(),
+            effectService: SpyEffectService(),
+            deviceService: device,
+            performanceService: perf,
+            scoreRepository: ScoreRepositoryImpl(modelContainer: container),
+            settingsRepository: SettingsRepositoryImpl(modelContainer: container),
+            statisticsRepository: StatisticsRepositoryImpl(modelContainer: container),
+            gameSettings: settings
+        )
+        // replenish 経路は randomPosition(screenBounds) を使うため実サイズを設定
+        vm.updateScreenBounds(CGRect(x: 0, y: 0, width: 400, height: 800))
+        return vm
+    }
+
+    private func makeBubbles(_ count: Int) -> [Bubble] {
+        (0..<count).map { _ in
+            Bubble(position: CGPoint(x: 100, y: 100), velocity: .zero, radius: 40,
+                   type: .normal, number: nil, color: .blue, alpha: 1.0, animationPhase: 0)
+        }
+    }
+
+    @Test("負荷が高いとバブルを目標数まで削減する")
+    func reducesBubblesUnderLoad() throws {
+        let perf = FakePerformanceService(); perf.adjustment = 0.5 // 20*0.5 = 10
+        let vm = try Self.makePerfViewModel(perf: perf, device: FakeDeviceService())
+        vm.bubbles = makeBubbles(20)
+
+        vm.optimizePerformance()
+
+        #expect(vm.bubbles.count == 10)
+    }
+
+    @Test("負荷回復後にバブルを目標数まで補充する")
+    func replenishesBubblesAfterRecovery() throws {
+        let perf = FakePerformanceService(); perf.adjustment = 1.0 // 20*1.0 = 20
+        let vm = try Self.makePerfViewModel(perf: perf, device: FakeDeviceService())
+        vm.bubbles = makeBubbles(8) // 負荷軽減で減った状態
+
+        vm.optimizePerformance()
+
+        #expect(vm.bubbles.count == 20)
+    }
+
+    @Test("定常状態では増減しない（1Hzちらつき防止）")
+    func noOpAtSteadyState() throws {
+        let perf = FakePerformanceService(); perf.adjustment = 1.0 // final = 20
+        let vm = try Self.makePerfViewModel(perf: perf, device: FakeDeviceService())
+        vm.bubbles = makeBubbles(20)
+
+        vm.optimizePerformance()
+
+        #expect(vm.bubbles.count == 20)
+    }
+
+    @Test("数字モードでは perf 調整を行わない（バブル集合はルール依存）")
+    func skipsAdjustmentInNumberedMode() throws {
+        let perf = FakePerformanceService(); perf.adjustment = 0.5 // normal なら 10 に減るはず
+        let vm = try Self.makePerfViewModel(perf: perf, device: FakeDeviceService(), gameMode: "numbered")
+        vm.bubbles = makeBubbles(20)
+
+        vm.optimizePerformance()
+
+        #expect(vm.bubbles.count == 20) // 数字モードは変化なし
     }
 }


### PR DESCRIPTION
## 概要
PR #27（#20）は**スタックPRの base が中間ブランチ**（`feature/issue-19`）だったため、マージしても **main に着地していなかった**。コミット `010301a` `74abda2` を現 main へ cherry-pick して再着地させる。

Closes #20 / refs #5

## 内容（PR #27 と同一）
- **#7 DI**: `EffectService` protocol に `setParticleEffectViewModel(_:)` を追加し、`setupParticleEffectViewModel` の `as? EffectServiceImpl` ダウンキャストを除去。
- **#8 perf回復**: `optimizePerformance()` を双方向化（削減＋回復時の補充）。定常状態は no-op、数字モードはガード。`updateGame` の呼び出しを ungated 化。

## 検証
- 2コミットを現 main へ cherry-pick → **auto-merge（衝突なし）**
- `BubblePopGameTests` 全グリーン（DI/perf テスト4件含む）

## 検証の正直性
`optimizePerformance` のロジックは unit test 済み。`updateGame` 内の毎tick実行（低FPS→回復の実走）は simulator で誘発不能なため **inspection-only**。

> base=main。#19 (PR #29) とは GameViewModel/EffectService の別メソッドを触るため独立着地で衝突しない。マージ順は任意。

🤖 Generated with [Claude Code](https://claude.com/claude-code)