### PR TITLE
chore: 輸出コンプラを事前申告（ITSAppUsesNonExemptEncryption=NO）(#25)

### DIFF
--- a/app/BubblePopGame.xcodeproj/project.pbxproj
+++ b/app/BubblePopGame.xcodeproj/project.pbxproj
@@ -410,6 +410,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.asapapalab.BubblePopGame;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -438,6 +439,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.asapapalab.BubblePopGame;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
## 概要
TestFlight/ASC で毎ビルド「Determine Compliance Requirements（輸出コンプライアンス）」の質問が出る問題を解消。本アプリは non-exempt な暗号化を使わないため `false` を事前申告する。

Closes #25 / refs #5

## 変更
- `GENERATE_INFOPLIST_FILE = YES`（自動生成 Info.plist）のため、app ターゲットの **Debug/Release 両 config** に `INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO` を追加。
- Tests/UITests ターゲットには付与しない。

## 検証
- Debug ビルド成功
- 生成された `Info.plist` に `ITSAppUsesNonExemptEncryption = false` が入ることを `PlistBuddy` で確認:
  ```
  /usr/libexec/PlistBuddy -c "Print :ITSAppUsesNonExemptEncryption" .../BubblePopGame.app/Info.plist → false
  ```

> base=main。GameViewModel 等に触れない完全独立変更（#29/#30 と非干渉）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)