### PR TITLE
fix: Start のデッドロック防止（候補修正）＋起動診断ログ (refs #23)

### DIFF
--- a/app/BubblePopGame/ViewModels/GameViewModel.swift
+++ b/app/BubblePopGame/ViewModels/GameViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftUI
 import QuartzCore
+import os
 
 @Observable
 @MainActor
@@ -86,7 +87,15 @@ class GameViewModel {
     private var lastTouchTime: CFTimeInterval = 0
     private var touchResponseTimes: [CFTimeInterval] = []
     private let maxResponseTimeHistory = 10
-    
+
+    // 画面サイズ未供給で startGame() された場合の保留フラグ（Issue #23）。
+    // サイズ到達時に updateScreenBounds から自動開始し、永久デッドロックを防ぐ。
+    private var pendingStart = false
+
+    // 起動診断ログ。Release/TestFlight でも os_log として記録され Console.app で確認できる
+    // （debugLog は #if DEBUG で TestFlight では無効なため、原因切り分けには OSLog を使う）。
+    private let startLogger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "BubblePopGame", category: "GameStart")
+
     init(bubbleService: BubbleService,
          audioService: AudioService,
          effectService: EffectService,
@@ -108,13 +117,20 @@ class GameViewModel {
     }
     
     func updateScreenBounds(_ size: CGSize) {
-        screenBounds = CGRect(origin: .zero, size: size)
-        bubbleService.updateScreenBounds(screenBounds)
+        updateScreenBounds(CGRect(origin: .zero, size: size))
     }
-    
+
     func updateScreenBounds(_ bounds: CGRect) {
+        // 遷移中の geometry 取りこぼし（.zero/不正サイズ）で有効値を上書きしない（Issue #23）。
+        guard bounds.width > 0, bounds.height > 0 else { return }
         screenBounds = bounds
         bubbleService.updateScreenBounds(bounds)
+
+        // サイズ未供給で保留されていた開始要求があれば、ここで自動開始（Issue #23）。
+        if pendingStart {
+            pendingStart = false
+            startGame()
+        }
     }
     
     // パフォーマンス最適化メソッド。
@@ -151,13 +167,19 @@ class GameViewModel {
     }
     
     func startGame() {
-        // screenBounds 未設定（View マウント前）の場合はバブル生成を遅延
-        // GameView.onAppear で updateScreenBounds → startGame の順に呼ばれる
+        startLogger.notice("startGame entry: screenBounds=\(self.screenBounds.debugDescription, privacy: .public), gameState=\(String(describing: self.gameState), privacy: .public)")
+        // screenBounds 未設定（View マウント前/遷移中の取りこぼし）の場合は開始を保留し、
+        // updateScreenBounds でサイズ到達時に自動開始する（Issue #23: 永久デッドロック防止）。
+        // PR #10 のガード意図（.zero でバブル生成しない）は維持。
         guard screenBounds != .zero else {
+            pendingStart = true
+            startLogger.notice("startGame deferred: screenBounds is .zero (pendingStart=true)")
             return
         }
+        pendingStart = false
 
         gameState = .playing
+        startLogger.notice("startGame: gameState -> .playing")
         score = 0
         timeRemaining = effectiveGameTime
         bubblesPopped = 0

--- a/app/BubblePopGameTests/CriticalBugFixTests.swift
+++ b/app/BubblePopGameTests/CriticalBugFixTests.swift
@@ -91,6 +91,42 @@ struct CriticalBugFixTests {
         #expect(!vm.bubbles.isEmpty)
     }
 
+    // MARK: - 1.1b Start デッドロック防止 (#23)
+
+    @Test("screenBounds 未設定で Start しても、サイズ到達時に自動でゲーム開始する（#23 デッドロック防止）")
+    func startIsDeferredUntilScreenBoundsAvailable() throws {
+        let vm = try Self.makeViewModel()
+        vm.gameState = .menu
+
+        // screenBounds が .zero のまま Start → 即 playing にはせず保留（PR #10 ガード維持）
+        vm.startGame()
+        #expect(vm.gameState == .menu, "サイズ未供給時は保留（まだ playing にしない）")
+        #expect(vm.bubbles.isEmpty, "PR #10 ガード: .zero でバブル生成しない")
+
+        // 画面サイズが到達 → 保留分が自動でゲーム開始（永久デッドロックを防ぐ）
+        vm.updateScreenBounds(CGRect(x: 0, y: 0, width: 400, height: 800))
+        #expect(vm.gameState == .playing, "サイズ到達で保留分が自動開始する")
+        #expect(!vm.bubbles.isEmpty)
+
+        vm.pauseGame() // タイマー/ループ停止
+    }
+
+    @Test("有効な screenBounds は .zero で上書きされない（#23 クロバー防止）")
+    func validScreenBoundsNotClobberedByZero() throws {
+        let vm = try Self.makeViewModel()
+        vm.updateScreenBounds(CGRect(x: 0, y: 0, width: 400, height: 800))
+
+        // 遷移中の geometry 取りこぼし（.zero）が有効値を壊さないこと
+        vm.updateScreenBounds(CGRect.zero)
+        vm.gameState = .menu
+        vm.startGame()
+
+        #expect(vm.gameState == .playing, ".zero で上書きされず Start が機能する")
+        #expect(!vm.bubbles.isEmpty)
+
+        vm.pauseGame()
+    }
+
     // MARK: - 1.2 時間表示
 
     @Test("gameTime=120 で startGame すると timeRemaining も 120")


### PR DESCRIPTION
## 概要
#23「Start を押してもゲームが始まらない（TestFlight 実機）」への **候補修正＋診断ログ**。

> ⚠️ **この環境では #23 を再現・確定できない**（実機なし／`simctl` タップ不可／**XCUITest ランナー起動不可**）。根本原因を断定できないため、最有力経路を安全に塞ぐ hardening と原因切り分け用ログを入れる。**`refs #23`（`Closes` ではない）。TestFlight 実機で検証するまで #23 はクローズしない。**

## 症状（スクショより）
TestFlight 実機でメニューの「Start Game」を押下後もメニューに留まり、ゲーム画面へ遷移しない。

## 根本原因の見立て（未確定）
`startGame()` 冒頭の `guard screenBounds != .zero else { return }` が、LaunchScreen→ContentView のアニメ遷移中に screenBounds 供給を取りこぼし `.zero` のまま呼ばれた場合、**early-return → gameState が .menu のまま** になる経路が有力。

## 変更
- **`updateScreenBounds`**: `.zero`/不正サイズを無視（遷移中の取りこぼしで有効値を上書きしない）。`CGSize` 版は `CGRect` 版へ委譲。
- **`startGame`**: `screenBounds == .zero` なら early-return でなく `pendingStart` に保留し、`updateScreenBounds` でサイズ到達時に**自動開始**。永久デッドロックを防ぐ。**PR #10 のガード意図（.zero でバブル生成しない）は維持**。
- **OSLog 診断**: `startGame` に `Logger.notice` を追加。`debugLog` は `#if DEBUG` で TestFlight では無効なため、Release でも記録される `os_log` で①ガード early-return ②gameState は変わるが view 非切替 ③ボタン未発火 を切り分け可能に（Console.app / device logs で確認）。
- `UIScreen.main` フォールバックは PR #10 の off-screen 生成バグ再発リスクのため**不採用**。

## テスト
TDD（#23 の2メカニズムを失敗テスト先行→実装）:
- ✅ `startIsDeferredUntilScreenBoundsAvailable` — サイズ未供給で Start→保留→サイズ到達で自動開始
- ✅ `validScreenBoundsNotClobberedByZero` — 有効値が .zero で上書きされない
- ✅ 既存 `startGameGuardsAgainstZeroBounds` / `startGameTransitionsToPlayingFromMenuPath` 維持（#10 ガード意図保持）
- ✅ `BubblePopGameTests` 全グリーン / Release ビルド成功・新規警告なし

## マージ後の検証手順（TestFlight）
1. このブランチを含むビルドを TestFlight へ
2. 実機で Start を押下 → ゲーム開始するか確認
3. 開始しない場合は Console.app で `category:GameStart` の os_log を確認:
   - `startGame deferred` が出る → 原因①（screenBounds .zero）。本修正で解消されるはず
   - `gameState -> .playing` が出るのに画面が変わらない → 原因②（view 再描画）。別対応が必要
   - そもそも `startGame entry` が出ない → 原因③（ボタン未発火）

🤖 Generated with [Claude Code](https://claude.com/claude-code)