### PR TITLE
fix: チュートリアル練習バブルを自前 geometry で配置 (#24)

### DIFF
--- a/app/BubblePopGame/Views/TutorialView.swift
+++ b/app/BubblePopGame/Views/TutorialView.swift
@@ -11,6 +11,9 @@ struct TutorialView: View {
     let gameViewModel: GameViewModel
     @State private var currentStep: Int = 0
     @State private var tutorialBubbles: [Bubble] = []
+    // TutorialView 自身の描画サイズ。練習バブル配置に使用（共有 screenBounds は
+    // 起動遷移中に .zero になりうるため #24）。
+    @State private var canvasSize: CGSize = .zero
     @State private var showTapHint = false
     @State private var hasCompletedTap = false
     @State private var tutorialScore = 0
@@ -124,15 +127,20 @@ struct TutorialView: View {
                     }
             )
             .onAppear {
+                canvasSize = geometry.size
                 gameViewModel.updateScreenBounds(geometry.frame(in: .local))
                 if currentStep == 2 {
                     setupTutorialBubbles()
                 }
-                
+
                 // チュートリアル開始時にBGMを再生
                 if gameViewModel.gameSettings.bgmEnabled && gameViewModel.gameSettings.bgmTrack != "off" {
                     gameViewModel.audioService.playBGMTrack(gameViewModel.gameSettings.bgmTrack, loop: true)
                 }
+            }
+            .onChange(of: geometry.size) { _, newSize in
+                // レイアウト確定/回転で描画サイズを更新（#24: 練習バブルを正しい位置に）
+                canvasSize = newSize
             }
         }
     }
@@ -357,15 +365,18 @@ struct TutorialView: View {
         hasCompletedTap = false
         showTapHint = false
         tutorialScore = 0
-        
-        // 画面の下部4分の1の領域に配置（文字と重複しないよう）
-        let screenHeight = gameViewModel.screenBounds.height
-        let screenWidth = gameViewModel.screenBounds.width
-        let bubbleY = screenHeight * 0.75 // 画面の下部4分の1
-        let bubbleX = screenWidth * 0.5   // 画面の中央
-        
+
+        // TutorialView 自身の描画サイズを使用（#24）。共有 gameViewModel.screenBounds は
+        // 起動遷移中に .zero になりうり、その場合バブルが (0,0) に置かれて練習エリアに
+        // 表示されなくなる。canvasSize が未確定なら screenBounds をフォールバックに使う。
+        var size = canvasSize
+        if size.width <= 0 || size.height <= 0 {
+            size = gameViewModel.screenBounds.size
+        }
+        let position = Self.tutorialBubblePosition(in: size)
+
         let centerBubble = Bubble(
-            position: CGPoint(x: bubbleX, y: bubbleY),
+            position: position,
             velocity: CGVector.zero,
             radius: 50,
             type: .normal,
@@ -375,6 +386,12 @@ struct TutorialView: View {
             animationPhase: 0.0
         )
         tutorialBubbles.append(centerBubble)
+    }
+
+    /// 練習バブルの配置位置（画面下部中央・文字と重複しない下部4分の1）。
+    /// テスト容易性のため純粋関数として切り出し（#24）。
+    static func tutorialBubblePosition(in size: CGSize) -> CGPoint {
+        CGPoint(x: size.width * 0.5, y: size.height * 0.75)
     }
     
     private func handleTutorialTap(at location: CGPoint) {

--- a/app/BubblePopGameTests/TutorialBubblePositionTests.swift
+++ b/app/BubblePopGameTests/TutorialBubblePositionTests.swift
@@ -1,0 +1,30 @@
+//
+//  TutorialBubblePositionTests.swift
+//  BubblePopGameTests
+//
+//  Issue #24: チュートリアル練習バブルの配置位置
+//
+
+import Testing
+import Foundation
+import CoreGraphics
+@testable import BubblePopGame
+
+@MainActor
+@Suite("チュートリアル練習バブル配置 (Issue #24)")
+struct TutorialBubblePositionTests {
+
+    @Test("練習バブルは渡された画面サイズの下部中央に配置される")
+    func positionUsesProvidedSize() {
+        let pos = TutorialView.tutorialBubblePosition(in: CGSize(width: 400, height: 800))
+        #expect(pos.x == 200) // width * 0.5
+        #expect(pos.y == 600) // height * 0.75
+    }
+
+    @Test("有効サイズなら原点(0,0)には置かれない（#24 リグレッション）")
+    func positionIsNotOriginForValidSize() {
+        let pos = TutorialView.tutorialBubblePosition(in: CGSize(width: 393, height: 852))
+        #expect(pos.x > 0)
+        #expect(pos.y > 0)
+    }
+}


### PR DESCRIPTION
## 概要
#24「チュートリアル練習ステップで、タップ対象のシャボン玉が表示されない」を修正。

Closes #24 / refs #5

## 症状（スクショより）
チュートリアルの練習ステップ「Let's try it! / Try tapping the bubble below / 👇 Tap here!」で、**「Tap here!」の下にタップすべきバブルが見当たらない**（空白）。練習を進められない。

## 根本原因
`setupTutorialBubbles` が**共有の `gameViewModel.screenBounds`** でバブル位置を計算していた:
```swift
let bubbleY = gameViewModel.screenBounds.height * 0.75
let bubbleX = gameViewModel.screenBounds.width  * 0.5
```
起動遷移中に `screenBounds` が `.zero` だと `(0,0)`＝**画面左上**に配置され、練習エリアに表示されない（#23 と同根の screenBounds `.zero` 問題）。TutorialView は**自前の GeometryReader を持つ**のに、壊れやすい共有値を使っていたのが直接原因。

## 修正
- **TutorialView 自身の描画サイズ（`canvasSize`）で配置**。描画時に必ず有効なため、共有 `screenBounds` の取りこぼしに依存しない。`onAppear` / `onChange(of: geometry.size)` で `canvasSize` を維持。未確定時のみ `screenBounds` をフォールバック。
- 位置計算を `tutorialBubblePosition(in:)` 純粋関数に切り出し（テスト容易化）。

## テスト
- ✅ `tutorialBubblePosition` が下部中央 `(width*0.5, height*0.75)` を返す
- ✅ 有効サイズで原点 `(0,0)` に置かれない（#24 リグレッション）
- ✅ `BubblePopGameTests` 全グリーン / Release 警告なし

## マージ前 手動確認チェックリスト（View 層のため必須）
> ⚠️ 練習ステップ(3つ目)は Next タップで到達するため `simctl`/XCUITest（本環境では起動不可）で自動検証不可。レビュア手動確認推奨。

- [ ] 初回起動 → チュートリアルを Next で練習ステップまで進める
- [ ] 「Tap here!」の下に青いバブルが表示される
- [ ] バブルをタップすると割れて次へ進める

> base=main。GameViewModel に触れず TutorialView/テストのみ（#23 PR #32 と非干渉）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)