### PR TITLE
feat: 制限時間デフォルトを30秒に+既存ユーザー移行 (#35)

### DIFF
--- a/app/BubblePopGame/BubblePopGameApp.swift
+++ b/app/BubblePopGame/BubblePopGameApp.swift
@@ -53,6 +53,11 @@ struct BubblePopGameApp: App {
         WindowGroup {
             LaunchScreenView()
                 .modelContainer(modelContainer)
+                .task {
+                    GameTimeDefaultMigration.runIfNeeded(
+                        repository: SettingsRepositoryImpl(modelContainer: modelContainer)
+                    )
+                }
         }
     }
 }

--- a/app/BubblePopGame/Models/GameScore.swift
+++ b/app/BubblePopGame/Models/GameScore.swift
@@ -19,7 +19,7 @@ class GameScore {
     var gameDuration: TimeInterval
     var gameTimeLimit: TimeInterval // 制限時間
     
-    init(score: Int, bubblesPopped: Int, accuracy: Double, gameMode: String, playDate: Date, gameDuration: TimeInterval, gameTimeLimit: TimeInterval = 60.0) {
+    init(score: Int, bubblesPopped: Int, accuracy: Double, gameMode: String, playDate: Date, gameDuration: TimeInterval, gameTimeLimit: TimeInterval = 30.0) {
         self.id = UUID()
         self.score = score
         self.bubblesPopped = bubblesPopped

--- a/app/BubblePopGame/Models/GameSettings.swift
+++ b/app/BubblePopGame/Models/GameSettings.swift
@@ -44,7 +44,7 @@ class GameSettings {
     init() {
         self.id = UUID()
         self.bubbleCount = 20
-        self.gameTime = 60.0
+        self.gameTime = 30.0
         self.bubbleMinRadius = 30.0
         self.bubbleMaxRadius = 60.0
         self.animationSpeed = 1.0

--- a/app/BubblePopGame/Services/GameTimeDefaultMigration.swift
+++ b/app/BubblePopGame/Services/GameTimeDefaultMigration.swift
@@ -15,20 +15,39 @@ enum GameTimeDefaultMigration {
     static let newDefault: Double = 30.0
 
     /// 起動時に 1 回だけ呼ぶ。センチネル済み・row 無し・旧デフォルト以外なら値を変えない。
-    /// row が無くてもセンチネルは立てる（毎起動の再 fetch を避ける）。
+    /// row が無い／移行不要／移行成功時のみセンチネルを立てる（毎起動の再 fetch を避ける）。
+    /// fetch/save が失敗した場合はセンチネルを立てずログのみ行い、次回起動で再試行する。
     static func runIfNeeded(repository: SettingsRepository, defaults: UserDefaults = .standard) {
         guard !defaults.bool(forKey: sentinelKey) else { return }
-        defer { defaults.set(true, forKey: sentinelKey) }
 
-        guard let settings = try? repository.fetchSettings() else { return }
-        if settings.gameTime == oldDefault {
-            settings.gameTime = newDefault
-            do {
-                try repository.saveSettings(settings)
-            } catch {
-                // sentinel は defer で立つため retry されない点に留意（クラッシュは避ける）
-                debugLog("GameTimeDefaultMigration: 移行の永続化に失敗 — \(error)")
-            }
+        let settings: GameSettings?
+        do {
+            settings = try repository.fetchSettings()
+        } catch {
+            // fetch 失敗時は sentinel を立てず、次回起動で再試行する
+            debugLog("GameTimeDefaultMigration: 設定の取得に失敗 — \(error)")
+            return
+        }
+
+        guard let settings else {
+            // 永続 row 無し（新規インストール等）。既定値が30なので移行不要。
+            defaults.set(true, forKey: sentinelKey)
+            return
+        }
+
+        guard settings.gameTime == oldDefault else {
+            // 旧デフォルト以外（手動設定値など）は尊重。移行不要。
+            defaults.set(true, forKey: sentinelKey)
+            return
+        }
+
+        settings.gameTime = newDefault
+        do {
+            try repository.saveSettings(settings)
+            defaults.set(true, forKey: sentinelKey)
+        } catch {
+            // 永続化失敗時は sentinel を立てず、次回起動で再試行する
+            debugLog("GameTimeDefaultMigration: 移行の永続化に失敗 — \(error)")
         }
     }
 }

--- a/app/BubblePopGame/Services/GameTimeDefaultMigration.swift
+++ b/app/BubblePopGame/Services/GameTimeDefaultMigration.swift
@@ -1,0 +1,29 @@
+//
+//  GameTimeDefaultMigration.swift
+//  BubblePopGame
+//
+//  #35: 制限時間デフォルトを 60→30 に変更した際の、既存ユーザー向け 1 回限り migration。
+//  旧デフォルト(60.0)のまま保存しているユーザーのみ 30.0 へ寄せる。手動で他の値にした人は尊重。
+//
+
+import Foundation
+
+@MainActor
+enum GameTimeDefaultMigration {
+    static let sentinelKey = "didMigrateDefaultGameTimeTo30"
+    static let oldDefault: Double = 60.0
+    static let newDefault: Double = 30.0
+
+    /// 起動時に 1 回だけ呼ぶ。センチネル済み・row 無し・旧デフォルト以外なら値を変えない。
+    /// row が無くてもセンチネルは立てる（毎起動の再 fetch を避ける）。
+    static func runIfNeeded(repository: SettingsRepository, defaults: UserDefaults = .standard) {
+        guard !defaults.bool(forKey: sentinelKey) else { return }
+        defer { defaults.set(true, forKey: sentinelKey) }
+
+        guard let settings = try? repository.fetchSettings() else { return }
+        if settings.gameTime == oldDefault {
+            settings.gameTime = newDefault
+            try? repository.saveSettings(settings)
+        }
+    }
+}

--- a/app/BubblePopGame/Services/GameTimeDefaultMigration.swift
+++ b/app/BubblePopGame/Services/GameTimeDefaultMigration.swift
@@ -23,7 +23,12 @@ enum GameTimeDefaultMigration {
         guard let settings = try? repository.fetchSettings() else { return }
         if settings.gameTime == oldDefault {
             settings.gameTime = newDefault
-            try? repository.saveSettings(settings)
+            do {
+                try repository.saveSettings(settings)
+            } catch {
+                // sentinel は defer で立つため retry されない点に留意（クラッシュは避ける）
+                debugLog("GameTimeDefaultMigration: 移行の永続化に失敗 — \(error)")
+            }
         }
     }
 }

--- a/app/BubblePopGame/ViewModels/GameViewModel.swift
+++ b/app/BubblePopGame/ViewModels/GameViewModel.swift
@@ -15,7 +15,7 @@ import os
 class GameViewModel {
     var gameState: GameState = .menu
     var score: Int = 0
-    var timeRemaining: Double = 60.0
+    var timeRemaining: Double = 30.0
     var bubbles: [Bubble] = []
     var screenBounds: CGRect = .zero
     var bubblesPopped: Int = 0

--- a/app/BubblePopGameTests/BasicPropertyTests.swift
+++ b/app/BubblePopGameTests/BasicPropertyTests.swift
@@ -17,7 +17,7 @@ struct GameSettingsTests {
         
         // 基本プロパティのデフォルト値テスト
         #expect(settings.bubbleCount == 20)
-        #expect(settings.gameTime == 60.0)
+        #expect(settings.gameTime == 30.0)
         #expect(settings.bubbleMinRadius == 30.0)
         #expect(settings.bubbleMaxRadius == 60.0)
         #expect(settings.animationSpeed == 1.0)

--- a/app/BubblePopGameTests/GameTimeMigrationTests.swift
+++ b/app/BubblePopGameTests/GameTimeMigrationTests.swift
@@ -1,0 +1,84 @@
+//
+//  GameTimeMigrationTests.swift
+//  BubblePopGameTests
+//
+//  #35: 制限時間デフォルト 60→30 の既存ユーザー向け 1 回限り migration
+//
+
+import Testing
+import SwiftData
+import Foundation
+@testable import BubblePopGame
+
+@MainActor
+@Suite("制限時間デフォルト migration (#35)")
+struct GameTimeMigrationTests {
+
+    static func makeRepo() throws -> SettingsRepositoryImpl {
+        let schema = Schema([GameScore.self, GameStatistics.self, GameSettings.self])
+        let container = try ModelContainer(
+            for: schema,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        return SettingsRepositoryImpl(modelContainer: container)
+    }
+
+    /// テスト隔離用 UserDefaults。一意 suite を作り、開始時に空にする。
+    static func makeDefaults(_ name: String) -> UserDefaults {
+        let d = UserDefaults(suiteName: name)!
+        d.removePersistentDomain(forName: name)
+        return d
+    }
+
+    @Test("旧デフォルト60のユーザーは30へ移行する")
+    func migratesSixtyToThirty() throws {
+        let repo = try Self.makeRepo()
+        let settings = GameSettings()
+        settings.gameTime = 60.0
+        try repo.saveSettings(settings)
+        let defaults = Self.makeDefaults("test.migrate.sixty")
+
+        GameTimeDefaultMigration.runIfNeeded(repository: repo, defaults: defaults)
+
+        #expect(try repo.fetchSettings()?.gameTime == 30.0)
+        #expect(defaults.bool(forKey: GameTimeDefaultMigration.sentinelKey) == true)
+    }
+
+    @Test("手動で90にしたユーザーは不変")
+    func leavesNinetyUnchanged() throws {
+        let repo = try Self.makeRepo()
+        let settings = GameSettings()
+        settings.gameTime = 90.0
+        try repo.saveSettings(settings)
+        let defaults = Self.makeDefaults("test.migrate.ninety")
+
+        GameTimeDefaultMigration.runIfNeeded(repository: repo, defaults: defaults)
+
+        #expect(try repo.fetchSettings()?.gameTime == 90.0)
+    }
+
+    @Test("センチネル済みなら何もしない")
+    func skipsWhenAlreadyMigrated() throws {
+        let repo = try Self.makeRepo()
+        let settings = GameSettings()
+        settings.gameTime = 60.0
+        try repo.saveSettings(settings)
+        let defaults = Self.makeDefaults("test.migrate.done")
+        defaults.set(true, forKey: GameTimeDefaultMigration.sentinelKey)
+
+        GameTimeDefaultMigration.runIfNeeded(repository: repo, defaults: defaults)
+
+        #expect(try repo.fetchSettings()?.gameTime == 60.0)
+    }
+
+    @Test("永続row無しでもクラッシュせずセンチネルを立てる")
+    func handlesNoPersistedRow() throws {
+        let repo = try Self.makeRepo()
+        let defaults = Self.makeDefaults("test.migrate.norow")
+
+        GameTimeDefaultMigration.runIfNeeded(repository: repo, defaults: defaults)
+
+        #expect(try repo.fetchSettings() == nil)
+        #expect(defaults.bool(forKey: GameTimeDefaultMigration.sentinelKey) == true)
+    }
+}

--- a/app/BubblePopGameTests/GameTimeMigrationTests.swift
+++ b/app/BubblePopGameTests/GameTimeMigrationTests.swift
@@ -82,4 +82,50 @@ struct GameTimeMigrationTests {
         #expect(try repo.fetchSettings() == nil)
         #expect(defaults.bool(forKey: GameTimeDefaultMigration.sentinelKey) == true)
     }
+
+    // MARK: - 失敗時に sentinel を立てない（次回再試行）
+
+    @MainActor
+    final class ThrowingSettingsRepository: SettingsRepository {
+        enum FailMode { case fetch, save }
+        let failMode: FailMode
+        var stored: GameSettings?
+        struct StubError: Error {}
+
+        init(failMode: FailMode, stored: GameSettings? = nil) {
+            self.failMode = failMode
+            self.stored = stored
+        }
+        func saveSettings(_ settings: GameSettings) throws {
+            if failMode == .save { throw StubError() }
+            stored = settings
+        }
+        func fetchSettings() throws -> GameSettings? {
+            if failMode == .fetch { throw StubError() }
+            return stored
+        }
+        func resetToDefaults() throws {}
+    }
+
+    @Test("fetch 失敗時は sentinel を立てない（次回再試行できる）")
+    func fetchFailureDoesNotBurnSentinel() throws {
+        let repo = ThrowingSettingsRepository(failMode: .fetch)
+        let defaults = Self.makeDefaults("test.migrate.fetchfail")
+
+        GameTimeDefaultMigration.runIfNeeded(repository: repo, defaults: defaults)
+
+        #expect(defaults.bool(forKey: GameTimeDefaultMigration.sentinelKey) == false)
+    }
+
+    @Test("save 失敗時は sentinel を立てない（次回再試行できる）")
+    func saveFailureDoesNotBurnSentinel() throws {
+        let sixty = GameSettings()
+        sixty.gameTime = 60.0
+        let repo = ThrowingSettingsRepository(failMode: .save, stored: sixty)
+        let defaults = Self.makeDefaults("test.migrate.savefail")
+
+        GameTimeDefaultMigration.runIfNeeded(repository: repo, defaults: defaults)
+
+        #expect(defaults.bool(forKey: GameTimeDefaultMigration.sentinelKey) == false)
+    }
 }

--- a/app/BubblePopGameTests/GameTimeMigrationTests.swift
+++ b/app/BubblePopGameTests/GameTimeMigrationTests.swift
@@ -55,6 +55,7 @@ struct GameTimeMigrationTests {
         GameTimeDefaultMigration.runIfNeeded(repository: repo, defaults: defaults)
 
         #expect(try repo.fetchSettings()?.gameTime == 90.0)
+        #expect(defaults.bool(forKey: GameTimeDefaultMigration.sentinelKey) == true)
     }
 
     @Test("センチネル済みなら何もしない")

--- a/app/BubblePopGameTests/SimpleGameViewModelTests.swift
+++ b/app/BubblePopGameTests/SimpleGameViewModelTests.swift
@@ -18,7 +18,7 @@ struct SimpleGameViewModelTests {
         let settings = GameSettings()
         
         #expect(settings.bubbleCount == 20)
-        #expect(settings.gameTime == 60.0)
+        #expect(settings.gameTime == 30.0)
         #expect(settings.soundEnabled == true)
         #expect(settings.vibrationEnabled == true)
         #expect(settings.gameMode == "normal")

--- a/app/BubblePopGameTests/SimpleSwiftDataTests.swift
+++ b/app/BubblePopGameTests/SimpleSwiftDataTests.swift
@@ -42,7 +42,7 @@ struct SimpleSwiftDataTests {
         
         // デフォルト値の確認
         #expect(settings.bubbleCount == 20)
-        #expect(settings.gameTime == 60.0)
+        #expect(settings.gameTime == 30.0)
         #expect(settings.soundEnabled == true)
         #expect(settings.vibrationEnabled == true)
         #expect(settings.gameMode == "normal")


### PR DESCRIPTION
## 概要
- 制限時間デフォルトを **60→30 秒** に変更（`GameSettings.init` / `GameScore.init` 既定引数 / `GameViewModel.timeRemaining` 初期値）。
- 旧デフォルト60のまま保存している既存ユーザーのみ30へ寄せる **UserDefaults センチネル付き1回限り migration** を追加。手動で他の値（90等）にした人は尊重。
- 全ユーザーが通る **起動時 root `.task`**（`BubblePopGameApp` の `LaunchScreenView`）で `GameTimeDefaultMigration.runIfNeeded` を実行（設定画面に紐付けると設定を開かないユーザーに発火しないため不可）。
- migration は best-effort: fetch/save 失敗時は sentinel を立てず `debugLog` で記録し**次回起動で再試行**（握り潰して永久未移行になるのを防止）。

## 実装メモ
- 既存テストでデフォルト60前提の3アサーションを30へ更新。`DebugOverrideTests`（明示的に `gameTime:60` を渡す override 隔離テスト）と `SimpleSwiftDataTests`（明示 `gameTimeLimit:60.0`）は**正しく60据え置き**。
- migration ロジックは6テストで保護（60→30 / 90不変 / sentinel済スキップ / row無し / fetch失敗で再試行 / save失敗で再試行）。
- スコア保存は常に `gameTimeLimit: effectiveGameTime` を明示渡しのため `GameScore` 既定変更の実害なし。
- 起動クラッシュなしをシミュレータで確認済み（fresh install → tutorial へ正常遷移、`.task` migration がクラッシュしない）。

## Test plan
- [x] migration ユニットテスト全6件 green
- [x] 全 UnitTest スイート green
- [x] シミュレータ起動でクラッシュなし（fresh install 経路）
- [ ] ⚠️ **既存ユーザー移行は install-over で検証**（main ビルドで一度起動して60を永続化 → アプリを**削除/erase せず**同 bundle id に feature ビルドを `simctl install` 上書き → 起動後 Settings が **30** になる）。erase すると SwiftData ストアが消えて fresh-install 経路しか試せない点に注意。
- [ ] その状態から **45** に設定 → 再起動で **45** 維持（sentinel が再移行を防ぐ）
- [ ] main ビルドで **90** にした既存ユーザー → feature 上書き起動で **90** 維持
- [ ] fresh install（クリーン）で初期値 **30**
- [ ] 数回コールドローンチして `.task` migration と splash 遷移の race が無いこと（#23/#24 の起動シーケンス履歴に鑑み確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)