### PR TITLE
feat: DEBUG スクショ撮影モード + App Store スクショ合成スクリプト (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ fastlane/test_output
 
 # serena mcp
 .serena/cache
+app-store-assets/

--- a/app/BubblePopGame/ContentView.swift
+++ b/app/BubblePopGame/ContentView.swift
@@ -141,6 +141,12 @@ struct ContentView: View {
         // 初期遷移先の判定と GameViewModel の実効値 override のみをローカルに決定する。
         #if DEBUG
         let debugOptions = DebugLaunchOptions(arguments: CommandLine.arguments)
+        // --screenshot=<画面>: App Store スクショ撮影用に起動直後の画面へ直行（DEBUG専用・リリース未影響）
+        if let shot = debugOptions.screenshot {
+            configureForScreenshot(shot, viewModel: viewModel)
+            self.gameViewModel = viewModel
+            return
+        }
         // --skip-tutorial: チュートリアルを bypass する（Issue #8）
         let shouldShowTutorial = gameSettings.isFirstLaunch && !debugOptions.skipTutorial
         // --game-time / --game-mode: GameViewModel の実効値を override（Issue #13）。
@@ -157,6 +163,35 @@ struct ContentView: View {
 
         self.gameViewModel = viewModel
     }
+
+    #if DEBUG
+    /// App Store スクショ撮影用: 起動直後に指定画面を表示し、必要ならサンプルデータを注入する。
+    /// `--screenshot=<画面>` 起動引数からのみ呼ばれる。リリースビルドには含まれない。
+    private func configureForScreenshot(_ screen: String, viewModel: GameViewModel) {
+        switch screen {
+        case "game", "game-normal":
+            viewModel.startGame()
+        case "game-numbered":
+            viewModel.debugGameModeOverride = "numbered"
+            viewModel.startGame()
+        case "result":
+            // 見栄えのするサンプル結果を注入（正確率 = successfulTaps/totalTaps = 96/104 ≈ 92%）
+            viewModel.score = 1280
+            viewModel.bubblesPopped = 96
+            viewModel.bestStreak = 18
+            viewModel.totalTaps = 104
+            viewModel.successfulTaps = 96
+            viewModel.timeRemaining = 0
+            viewModel.gameState = .gameOver
+        case "settings":
+            viewModel.gameState = .settings
+        case "highscore":
+            viewModel.gameState = .highScore
+        default: // "menu" 含む
+            viewModel.gameState = .menu
+        }
+    }
+    #endif
     
     private func resumeBGMOnMenuReturn(gameViewModel: GameViewModel) {
         // BGMが有効でトラックが設定されているが現在再生されていない場合に再開

--- a/app/BubblePopGame/Utils/DebugLaunchOptions.swift
+++ b/app/BubblePopGame/Utils/DebugLaunchOptions.swift
@@ -26,16 +26,20 @@ struct DebugLaunchOptions {
     let gameTime: Double?
     /// `--game-mode=<モード>`: ゲームモードの override（GameMode の rawValue 文字列）
     let gameMode: String?
+    /// `--screenshot=<画面>`: App Store スクショ撮影用に起動直後の表示画面へ直行
+    /// （`menu`/`game`/`game-numbered`/`result`/`settings`/`highscore`）。DEBUG 専用。
+    let screenshot: String?
 
     /// いずれかの override が指定されているか
     var hasOverrides: Bool {
-        skipTutorial || gameTime != nil || gameMode != nil
+        skipTutorial || gameTime != nil || gameMode != nil || screenshot != nil
     }
 
     init(arguments: [String]) {
         self.skipTutorial = arguments.contains("--skip-tutorial")
         self.gameTime = Self.value(for: "--game-time=", in: arguments).flatMap(Double.init)
         self.gameMode = Self.value(for: "--game-mode=", in: arguments)
+        self.screenshot = Self.value(for: "--screenshot=", in: arguments)
     }
 
     /// `--key=value` 形式の引数から value 部分を取り出す（空文字列は nil 扱い）

--- a/app/BubblePopGameTests/DebugLaunchOptionsTests.swift
+++ b/app/BubblePopGameTests/DebugLaunchOptionsTests.swift
@@ -18,6 +18,7 @@ struct DebugLaunchOptionsTests {
         #expect(options.skipTutorial == false)
         #expect(options.gameTime == nil)
         #expect(options.gameMode == nil)
+        #expect(options.screenshot == nil)
         #expect(options.hasOverrides == false)
     }
 
@@ -51,6 +52,13 @@ struct DebugLaunchOptionsTests {
     func gameModeParsing() {
         let options = DebugLaunchOptions(arguments: ["app", "--game-mode=numbered"])
         #expect(options.gameMode == "numbered")
+        #expect(options.hasOverrides == true)
+    }
+
+    @Test("--screenshot=result を文字列として解釈する")
+    func screenshotParsing() {
+        let options = DebugLaunchOptions(arguments: ["app", "--screenshot=result"])
+        #expect(options.screenshot == "result")
         #expect(options.hasOverrides == true)
     }
 

--- a/scripts/screenshots/README.md
+++ b/scripts/screenshots/README.md
@@ -1,0 +1,37 @@
+# App Store スクリーンショット生成
+
+App Store 提出用スクショを **半自動** で再生成する手順。UI 変更後に作り直すとき用。
+
+## 仕組み
+
+1. **DEBUG 起動引数 `--screenshot=<画面>`**（`ContentView.configureForScreenshot`、`#if DEBUG` 限定・リリース未影響）で、起動直後に任意画面へ直行する。`result` は見栄えのするサンプルスコアを注入。
+   - 対応画面: `menu` / `game` / `game-numbered` / `result` / `settings` / `highscore`
+2. **`simctl`** で iPhone / iPad シミュレータに各画面を表示させ生スクショを撮る（`simctl` はタップ不可なので、この起動引数で画面遷移を代替している）。
+3. **`compose_screenshots.py`**（Pillow）で「グラデ背景 + 上部の日本語見出し + デバイス枠」に合成し、App Store 必須解像度（6.9" / 6.5" / iPad 13"）で出力する。
+
+## 再生成手順
+
+```bash
+# 0) Pillow（初回のみ）
+python3 -m venv /tmp/bpg-venv && /tmp/bpg-venv/bin/pip install pillow
+
+# 1) Debug ビルド
+xcodebuild build -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -configuration Debug -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath /tmp/bpg-ss
+
+# 2) 生スクショ撮影（iPhone 17 Pro / iPad Pro 13"）
+#    各画面: xcrun simctl launch <UDID> com.asapapalab.BubblePopGame --screenshot=<画面>
+#    → 数秒待って xcrun simctl io <UDID> screenshot /tmp/bpg-shots/<device>-<画面>.png → terminate
+#    （BGM がデフォルト ON なので撮影後は必ず terminate すること）
+
+# 3) 合成（→ /tmp/bpg-final/ に出力）
+/tmp/bpg-venv/bin/python scripts/screenshots/compose_screenshots.py
+```
+
+生成物（`/tmp/bpg-final/` → `app-store-assets/screenshots/` にコピー）は `.gitignore` 対象。
+スクリプトと DEBUG 機能だけをバージョン管理し、画像は再生成可能とする。
+
+## 見出し文・配色の変更
+
+`compose_screenshots.py` の `JOBS`（画面ごとの日本語見出し）と `GRAD_TOP`/`GRAD_BOTTOM`（背景グラデ）を編集する。フォントは `ヒラギノ角ゴシック W7`。

--- a/scripts/screenshots/compose_screenshots.py
+++ b/scripts/screenshots/compose_screenshots.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""App Store 用スクショ合成スクリプト (#5)
+
+simctl で撮った生スクショ（/tmp/bpg-shots/{iphone,ipad}-<screen>.png）を、
+「グラデ背景 + 上部の日本語見出し + デバイス枠に収めたアプリ画面」に合成し、
+App Store 必須解像度（6.9" / 6.5" / iPad 13"）で出力する。
+
+実行:
+  /tmp/bpg-venv/bin/python scripts/screenshots/compose_screenshots.py
+依存: Pillow（venv に導入）/ macOS のヒラギノ角ゴシック
+"""
+import os
+from PIL import Image, ImageDraw, ImageFont, ImageFilter
+
+SRC_DIR = "/tmp/bpg-shots"
+OUT_DIR = "/tmp/bpg-final"
+FONT_BOLD = "/System/Library/Fonts/ヒラギノ角ゴシック W7.ttc"
+
+# 出力キャンバス（App Store 必須）と、使う生スクショの元デバイス
+CANVASES = {
+    "iphone-6.9_1290x2796": (1290, 2796, "iphone"),
+    "iphone-6.5_1242x2688": (1242, 2688, "iphone"),
+    "ipad-13_2064x2752":    (2064, 2752, "ipad"),
+}
+
+# (screen キー, 日本語見出し) ※絵文字なし
+JOBS = [
+    ("menu",          "美しいシャボン玉の世界へ"),
+    ("game",          "指先でシャボン玉をはじこう"),
+    ("game-numbered", "数字を順番に消すチャレンジ"),
+    ("result",        "あなたの記録を更新しよう"),
+    ("settings",      "自分好みに自由カスタマイズ"),
+]
+
+# ブランドのグラデ（上=濃いめの空色 → 下=淡い水色）
+GRAD_TOP = (74, 168, 232)
+GRAD_BOTTOM = (231, 246, 255)
+TEXT_COLOR = (255, 255, 255)
+SHADOW_COLOR = (20, 70, 110)
+
+
+def vertical_gradient(w, h, top, bottom):
+    col = Image.new("RGB", (1, h))
+    for y in range(h):
+        t = y / (h - 1)
+        col.putpixel((0, y), tuple(int(top[i] + (bottom[i] - top[i]) * t) for i in range(3)))
+    return col.resize((w, h)).convert("RGBA")
+
+
+def rounded_mask(size, radius):
+    m = Image.new("L", size, 0)
+    ImageDraw.Draw(m).rounded_rectangle([0, 0, size[0] - 1, size[1] - 1], radius=radius, fill=255)
+    return m
+
+
+def fit_font(text, max_w, start_px, font_path):
+    px = start_px
+    while px > 20:
+        f = ImageFont.truetype(font_path, px)
+        if f.getbbox(text)[2] <= max_w:
+            return f
+        px -= 2
+    return ImageFont.truetype(font_path, 20)
+
+
+def compose(raw_path, caption, out_path, canvas):
+    cw, ch, _ = canvas
+    bg = vertical_gradient(cw, ch, GRAD_TOP, GRAD_BOTTOM)
+    draw = ImageDraw.Draw(bg)
+
+    # --- 上部見出し ---
+    margin = int(cw * 0.07)
+    font = fit_font(caption, cw - 2 * margin, int(cw * 0.072), FONT_BOLD)
+    bbox = draw.textbbox((0, 0), caption, font=font)
+    tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
+    tx = (cw - tw) // 2 - bbox[0]
+    ty = int(ch * 0.055)
+    # 影 + 本体
+    draw.text((tx + 3, ty + 3), caption, font=font, fill=SHADOW_COLOR)
+    draw.text((tx, ty), caption, font=font, fill=TEXT_COLOR)
+
+    # --- デバイス枠にアプリ画面を収める ---
+    shot = Image.open(raw_path).convert("RGBA")
+    sw, sh = shot.size
+    # 画面領域の目標幅（キャンバス幅の比率）。残り縦に収まるよう高さでも制限。
+    top_zone = int(ch * 0.20)          # 見出しゾーン
+    bottom_margin = int(ch * 0.04)
+    avail_h = ch - top_zone - bottom_margin
+    bezel = max(10, int(cw * 0.013))   # 黒縁の太さ
+    target_w = int(cw * 0.80)
+    target_h = int(target_w * sh / sw)
+    if target_h + 2 * bezel > avail_h:
+        target_h = avail_h - 2 * bezel
+        target_w = int(target_h * sw / sh)
+    shot_resized = shot.resize((target_w, target_h))
+
+    # スクショ角丸
+    radius = max(24, int(target_w * 0.045))
+    shot_resized.putalpha(rounded_mask((target_w, target_h), radius))
+
+    # ベゼル（黒の角丸）
+    fw, fh = target_w + 2 * bezel, target_h + 2 * bezel
+    frame = Image.new("RGBA", (fw, fh), (0, 0, 0, 0))
+    ImageDraw.Draw(frame).rounded_rectangle(
+        [0, 0, fw - 1, fh - 1], radius=radius + bezel, fill=(22, 24, 28, 255)
+    )
+    frame.alpha_composite(shot_resized, (bezel, bezel))
+
+    fx = (cw - fw) // 2
+    fy = top_zone + (avail_h - fh) // 2
+
+    # ドロップシャドウ
+    shadow = Image.new("RGBA", (cw, ch), (0, 0, 0, 0))
+    sdraw = ImageDraw.Draw(shadow)
+    sdraw.rounded_rectangle(
+        [fx, fy + int(bezel * 1.5), fx + fw, fy + fh + int(bezel * 1.5)],
+        radius=radius + bezel, fill=(10, 40, 70, 110),
+    )
+    shadow = shadow.filter(ImageFilter.GaussianBlur(int(cw * 0.02)))
+    bg.alpha_composite(shadow)
+    bg.alpha_composite(frame, (fx, fy))
+
+    bg.convert("RGB").save(out_path, "PNG")
+    return out_path
+
+
+def main():
+    os.makedirs(OUT_DIR, exist_ok=True)
+    made = []
+    for cname, canvas in CANVASES.items():
+        device = canvas[2]
+        for i, (screen, caption) in enumerate(JOBS, start=1):
+            raw = os.path.join(SRC_DIR, f"{device}-{screen}.png")
+            if not os.path.exists(raw):
+                print(f"  SKIP (no raw): {raw}")
+                continue
+            out = os.path.join(OUT_DIR, f"{cname}__{i:02d}_{screen}.png")
+            compose(raw, caption, out, canvas)
+            made.append(out)
+            print(f"  OK: {out}")
+    print(f"\n生成 {len(made)} 枚 -> {OUT_DIR}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要
App Store 提出用スクショを半自動で再生成できる仕組みを追加。`simctl` がタップ不可な制約を、DEBUG 限定の起動引数で各画面へ直行させて回避する。

## 変更
- **`DebugLaunchOptions`**: `--screenshot=<画面>` を追加（`menu`/`game`/`game-numbered`/`result`/`settings`/`highscore`）。
- **`ContentView.configureForScreenshot`**（`#if DEBUG` 限定・リリース未影響）: 起動直後に指定画面へ直行。`result` は見栄えのするサンプルスコア（1280 / 正確率92.3%）を注入。
- **`scripts/screenshots/compose_screenshots.py`**（Pillow）: 生スクショを「グラデ背景＋上部の日本語見出し（ヒラギノ角ゴ W7）＋デバイス枠＋ドロップシャドウ」に合成し、6.9"(1290×2796) / 6.5"(1242×2688) / iPad 13"(2064×2752) で出力。
- **`scripts/screenshots/README.md`**: 再生成手順。
- **`DebugLaunchOptionsTests`**: `--screenshot` パーステスト追加。
- 生成画像 `app-store-assets/` は `.gitignore`（スクリプトで再生成可能。バイナリは非コミット）。

## 検証
- [x] Debug ビルド成功、`DebugLaunchOptionsTests` 全緑（新 `screenshotParsing()` 含む）
- [x] iPhone 17 Pro / iPad Pro 13" で全5画面を撮影 → 15枚を合成、目視確認（リザルトは「おしまい！」お祝いトーンで表示）
- リリース挙動への影響なし（`#if DEBUG` ガード）

🤖 Generated with [Claude Code](https://claude.com/claude-code)