### PR TITLE
docs: v1.0 リリース振り返り + ASC 提出ノウハウ反映

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ fastlane/test_output
 # serena mcp
 .serena/cache
 app-store-assets/
+
+# macOS
+.DS_Store
+**/.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,12 @@ app/BubblePopGame/
 - accessibility ラベル等、**スクショ/目視に映らないローカライズ文字列**を追加したら、「全新規キーが ja/en/Base の全ファイルに存在する」＋「3 ファイルのキー集合が一致する」ことを assert するユニットテストで守る。キー欠落・ロケール漏れは `simctl` の no-tap 検証や目視をすり抜けるため、テストで大声で検出させる（関連スキル: `xcstrings-bulk-update` / `xcstrings-plural-variations`）。**本プロジェクトには既に `LocalizationKeysTests`（必須キー存在＋ ja/en/Base パリティ）がある**ので、キー追加/削除時はこれが守る（1 ロケールだけ消し忘れるとパリティテストが落ちる）
 - ⚠️ **`String(format:)` の書式指定子と引数型の不一致は実行時に黙って壊れる**。`seconds_format = "%d秒"`（整数書式）に **Double** を渡すと 0／不正値になる（#37「Play Time 0 sec」の実際の原因。`SettingsView` は `Int(...)` キャスト済みだが `GameOverView` は Double を渡していた）。同じ format キーを複数箇所で使うと、片方が `Int(...)`・片方が Double で挙動が割れて目視をすり抜ける。format 系は型を揃え、計算は **testable な computed property（`Int` 返し等）に切り出してユニットテストで守る**（例: `GameViewModel.elapsedPlaySeconds`）
 
+### App Store 提出・スクショ検証
+
+- ✅ **simctl 自動スクショの上限は「起動画面のみ」ではない**。`#if DEBUG` 限定の起動引数で目的の `gameState` へ直行＋サンプルデータ注入すれば、ゲーム中／リザルト／設定など **tap 遷移が要る "売り" の画面も tap なしで全自動キャプチャ**できる。本プロジェクトは `--screenshot=<画面>` を実装済み（#43）。App Store スクショはこの DEBUG ナビ＋ Pillow 合成（`scripts/screenshots/compose_screenshots.py`、Hiragino フォント）で全自動生成できる。`simctl` に `tap` が無い制約は、DEBUG 起動引数で「画面遷移そのものを引数化」すれば回避できる（[[ios-simulator-app-verification]] の no-tap 検証の発展形）
+- ⚠️ **App Store スクショは `TARGETED_DEVICE_FAMILY` の全デバイスファミリ分が提出必須**。本プロジェクトは `"1,2"`（iPhone+iPad）なので、iPhone 6.9" だけでなく **iPad 13" のスクショも必須**（iPhone 分だけ用意すると審査で不足扱い）。撮影機シミュレータの実寸は必須解像度と一致不要で、合成時にデバイス枠内へスケール配置すればよい
+- ✅ **ASC 提出フィールド（説明文・キーワード・サブタイトル等）の単一ソースは `docs/app-store-metadata.md`**。コードと乖離した旧マーケ／分析 docs（旧リリース計画等）は削除済みなので、提出情報はこのファイルだけを最新化・参照する
+
 ### Git運用
 
 - `main` には直接コミットしない。`feature/issue-N-pr-X-<topic>` のような名前で feature branch を切る

--- a/docs/RELEASE_v1.0.md
+++ b/docs/RELEASE_v1.0.md
@@ -44,3 +44,59 @@
 
 ### マージ後
 - [ ] `git tag -a v1.0 -m "v1.0 (build 36) App Store 初回提出" && git push origin v1.0`（版の source-of-truth を残す。これが無いと次回また stale 判定が曖昧になる）
+
+---
+
+## 振り返り (Retrospective) — 2026-06-02 リリース完了
+
+> ✅ **2026-06-02、初版 v1.0 (build 36) が App Store 審査を通過しリリース済み**。本セクションは `release-retrospective` skill に基づくリリースサイクル（PR #6〜#43, 2026-05-26〜05-31）の振り返り。次の v1.x retro はこの節を起点に trend を追える。
+>
+> 初版のため retro 対象 PR は多いが、個々の技術的学びの大半は既に CLAUDE.md に継続追記済み（#11 / #28 / #34 / #38）。本節では **(a) リリース journey の俯瞰**、**(b) まだ CLAUDE.md に無い学び（特に ASC 実機提出ノウハウ）**、**(c) アクションアイテム表**に絞る。
+
+### リリース journey（テーマ別）
+
+| テーマ | 主な PR | 要点 |
+| --- | --- | --- |
+| 起動安定性（screenBounds systemic fault） | #6, #10, #32, #33 | 起動不能（#23）・チュートリアル練習バブル不可視（#24）が TestFlight まで漏れた。共有 `screenBounds == .zero` の供給取りこぼしが根本原因。deferred-start＋View 固有 geometry で解消 |
+| Swift 6 / コード品質 | #12, #29, #30 | EffectService protocol の `@MainActor` 化、debug print の `#if DEBUG` ログ化、DI 改善＋パフォーマンス回復 |
+| DEBUG 検証基盤（no-tap 自動化） | #14, #16, #43 | `--skip-tutorial` / `--game-time` / `--game-mode` / `--screenshot=<画面>` を配線。simctl の tap 不在を「画面遷移の引数化」で回避 |
+| ローカライズ | #15, #22 | ローカライズ漏れ修正、LaunchScreen 仕上げ＋英語重複解消。`LocalizationKeysTests` でキー存在＋ ja/en/Base パリティを担保 |
+| ゲーム体験 / 設定反映 | #21, #39, #40 | バブルサイズ・速度に GameSettings 反映、リザルト画面お祝いトーン化＋誤タップ防止、制限時間デフォルト 60→30 秒＋既存ユーザー migration |
+| App Store 提出準備 | #31, #41, #42, #43 | 輸出コンプラ事前申告、v1.0(build36) 提出準備＋privacy manifest、旧 docs 整理、スクショ全自動生成 |
+| プロセス改善（振り返りの複利） | #11, #28, #34, #38 | 罠を都度 CLAUDE.md 化し、次 PR で踏まない運用を確立 |
+
+### 良かった点（What went well）
+
+- **振り返りの複利が機能した**: 詰まった点を都度 CLAUDE.md に追記する運用（#11 / #28 / #34 / #38）で、同じ罠を後続 PR で踏まない流れが定着。session-retrospective skill＋Stop hook の仕組みが回った。
+- **no-tap 自動検証基盤を整備**: `simctl` に `tap` が無い制約を、`#if DEBUG` 起動引数（`--skip-tutorial` / `--game-time` / `--screenshot`）で「画面遷移そのものを引数化」して回避。起動確認だけでなく "売り" 画面のスクショまで全自動化できた。
+- **テストで盲点を守った**: `LocalizationKeysTests`（キー存在＋ロケールパリティ）、`GameTimeDefaultMigration`（in-memory ModelContainer でユニットテスト）、`elapsedPlaySeconds`（computed property 化）など、目視・no-tap 検証をすり抜ける箇所をテストで大声検出。
+- **スクショ全自動生成パイプライン**: DEBUG ナビ＋ Pillow 合成（`scripts/screenshots/compose_screenshots.py`）で必須スクショを自動生成。
+
+### 詰まった点 / 失敗（What went wrong）
+
+- **screenBounds == .zero が systemic fault として本番化**: #23（起動不能）/ #24（練習バブル不可視）が実際に TestFlight に出た。共有 `gameViewModel.screenBounds` が LaunchScreen→ContentView のアニメ遷移中に供給を取りこぼす設計上の脆さ。対処（無効値を上書きしない／deferred-start／View 固有 geometry）は CLAUDE.md 化済みだが、**共有可変状態に座標を載せる設計そのもの**は将来の改善余地。
+- **スタックPR のマージ順罠**: base が中間 feature ブランチの #26/#27 を先に main へ入れた結果、#19/#20 が main 未着地に。re-land 2 PR（#29/#30）の手戻りが発生。→ CLAUDE.md に「独立変更は base=main で切る」と明記済み。
+- **SwiftData migration の defer footgun**: `defer { setFlag }` を fetch ガードより前に置くと失敗も握り潰し「やった印」だけ立って永久未移行になる罠を #35 最終レビューで捕捉。
+- **`String(format:)` の型不一致で Play Time 0 sec**（#37）: 整数書式 `%d秒` に Double を渡して 0 表示。`SettingsView` は Int キャスト済み・`GameOverView` は Double で挙動が割れていた。
+- **単一テスト `-only-testing` の vacuous SUCCEEDED 罠**: メソッド単位指定で 0 件実行のまま `** TEST SUCCEEDED **` になり、RED 確認に使うと誤認。
+
+### 想定外の発見（Surprises）
+
+- ⚠️ **App Store のアプリ名は全世界で一意**（コード内の Bundle 名とは無関係）。計画していた `Bubble Pop Game` / `BubblePopGame` はどちらも他アプリが使用中で ASC に登録不可。土壇場で一意な **`Bubble Pop: Relax & Focus`** にリネーム（2026-05-31 ASC 登録時に確定）。
+- ⚠️ **ASC の説明文・プロモーションテキスト欄は絵文字を「無効な文字」として拒否**（🫧 だけでなく ✨🎵📱🌟💫🔒 等も全滅）。docs は絵文字込みで用意していたため入力時に手で除去する羽目に。ウェーブダッシュ `〜`(U+301C) も避け全角チルダ `～`(U+FF5E) を使う。箇条書き `•`・CJK 隅付き括弧 `【】` は OK。
+- ✅ **simctl 自動スクショの上限は「起動画面のみ」ではなかった**（ポジティブな発見）: DEBUG 起動引数で目的の `gameState` へ直行＋サンプルデータ注入すれば、tap が要る売り画面まで全自動キャプチャできた。
+- ⚠️ **App Store スクショは `TARGETED_DEVICE_FAMILY` の全ファミリ分が提出必須**: `"1,2"` のため iPhone 6.9" だけでなく iPad 13" も必要（本ドキュメント上部チェックリストの「6.5"/5.5"」は旧スペックで、実提出では現行の 6.9"＋iPad 13" を使用）。
+
+### 次サイクルへの遺産（Action items）
+
+| 学び | 行き先 | 状態 |
+| --- | --- | --- |
+| App Store スクショ自動化（DEBUG ナビ / 全デバイスファミリ必須 / metadata 単一ソース） | CLAUDE.md「App Store 提出・スクショ検証」セクション | ✅ 本 retro PR で追記 |
+| ASC 入力ノウハウ（アプリ名の全世界一意性 / 絵文字拒否 / U+301C vs U+FF5E / キーワード除外最適化） | memory（`asc-browser-input-quirks.md`）＋ skill 化（新規 vs 既存統合は要判断） | 🔲 ユーザー確認 |
+| `app-store-metadata.md` が却下された旧アプリ名のまま（origin/main 版） | docs 再適用（最終アプリ名 / ASC 警告 / キーワード最適化を絵文字復活なしで反映） | 🔲 本 retro PR で対応 |
+| 初版リリースのバージョン境界（タグ）が無い → 次回 retro の window 起点が取れない | `git tag v1.0`（提出前チェックリスト「マージ後」にも記載あり） | 🔲 ユーザー確認（push せず提案） |
+| release epic #5 完了 | Issue #5 クローズ | 🔲 ユーザー確認 |
+| テスト時間が長すぎる | 既存 Issue #44 | ✅ 登録済み |
+| screenBounds の共有可変状態設計そのものの脆さ | 将来の設計改善 Issue 化（候補） | 🔲 検討 |
+
+> アクションアイテム表がこの retro の心臓部。状態列で実行可否を追跡する。次の v1.x リリースはこの表の未消化項目を起点に triage する。

--- a/docs/app-store-metadata.md
+++ b/docs/app-store-metadata.md
@@ -4,13 +4,15 @@
 
 ### アプリ名
 - **日本語**: シャボン玉消しゲーム
-- **英語**: Bubble Pop Game
-- **文字数**: 日本語 9文字、英語 15文字（30文字制限内）
+- **英語**: Bubble Pop: Relax & Focus
+- **文字数**: 日本語 10文字、英語 25文字（30文字制限内）
+> ※ 当初の「Bubble Pop Game」「BubblePopGame」はどちらも他アプリが使用中で ASC に登録不可だったため、一意な「Bubble Pop: Relax & Focus」を採用（2026-05-31 ASC 登録時に確定）。App Store のアプリ名は全世界で一意。
 
 ### サブタイトル
 - **日本語**: 美しいシャボン玉で楽しむリラックスゲーム
-- **英語**: Relaxing game with beautiful soap bubbles
-- **文字数**: 日本語 19文字、英語 37文字（30文字制限内）
+- **英語**: Relaxing soap bubble game
+- **文字数**: 日本語 20文字、英語 25文字（30文字制限内）
+> ※ 旧英語サブタイトル「Relaxing game with beautiful soap bubbles」は 37 文字で 30 字制限超過だったため短縮（25 文字）。
 
 ### カテゴリ
 - **プライマリ**: ゲーム
@@ -29,6 +31,8 @@
 ---
 
 ## 📝 説明文
+
+> ⚠️ **ASC の文字制限（2026-05-31 実機検証）**: 説明文・プロモーションテキスト欄は**絵文字を「無効な文字」として拒否**する（🫧 だけでなく ✨🎵📱🌟💫🔒 等も全滅）。ウェーブダッシュ `〜`(U+301C) も避け、全角チルダ `～`(U+FF5E) を使う。箇条書き `•`(U+2022)・CJK 隅付き括弧 `【】` は OK。本ファイルの説明文・プロモは絵文字除去済み（#42）。
 
 ### 日本語版説明文 (4000文字制限)
 
@@ -159,13 +163,15 @@ Experience the simple yet profound, heartwarming world of soap bubbles!
 
 ### 日本語キーワード (100文字制限)
 ```
-シャボン玉,バブル,ゲーム,リラックス,カジュアル,癒し,アクション,パズル,家族,子供,大人,数字,順番,タイミング,反射神経,集中力,無料,シンプル,美しい,アニメーション,音楽,BGM,効果音,アクセシビリティ,VoiceOver
+バブル,癒し,カジュアル,アクション,パズル,数字,順番,タイミング,反射神経,集中力,無料,シンプル,アニメーション,BGM,効果音,アクセシビリティ,VoiceOver,家族,子供,大人
 ```
+> ※ アプリ名/サブタイトルに含まれる `シャボン玉` `ゲーム` `リラックス` は別枠でインデックスされるためキーワード欄から除外（約95文字）
 
 ### 英語キーワード (100文字制限)
 ```
-bubble,pop,soap bubbles,casual game,relaxing,family,kids,adults,numbers,sequence,timing,reflexes,concentration,free,simple,beautiful,animation,music,accessibility,VoiceOver,puzzle,action
+casual,family,kids,numbers,sequence,timing,reflexes,free,simple,animation,accessibility,voiceover
 ```
+> ※ アプリ名/サブタイトルに含まれる `bubble` `pop` `game` `relaxing` `soap` は除外。枠の都合で `music` `puzzle` `action` 等もカット（約97文字）
 
 ---
 
@@ -263,8 +269,9 @@ bubble,pop,soap bubbles,casual game,relaxing,family,kids,adults,numbers,sequence
 
 ### 英語 (170文字制限) — ⚠️ 絵文字禁止（ASC の en フィールドは絵文字を弾く）
 ```
-Soothing bubble popping game! Beautiful animations and healing music help you forget daily stress. Relax in normal mode, challenge in numbered mode. VoiceOver support for everyone. Free download now!
+Soothing bubble popping game! Beautiful animations and music melt away daily stress. Relax in normal mode or challenge numbered mode. VoiceOver supported. Free now!
 ```
+> ※ 旧版は約200字で170字制限超過のため短縮（約160字・絵文字なし）
 
 ---
 


### PR DESCRIPTION
## 概要
初版 **v1.0 (build 36)** が 2026-06-02 に App Store 審査を通過しリリース完了 🎉 — `release-retrospective` skill に基づくリリースサイクル（PR #6〜#43）の振り返りと、その学びの仕組み化。

## 変更内容
- **`docs/RELEASE_v1.0.md`**: 振り返りセクション追記（リリース journey / 良かった点 / 詰まった点 / 想定外の発見 / アクションアイテム表）
- **`CLAUDE.md`**: 「App Store 提出・スクショ検証」セクション追加
  - DEBUG 起動引数による no-tap スクショ自動化（`--screenshot=<画面>`）
  - スクショは `TARGETED_DEVICE_FAMILY` の全ファミリ分が提出必須（`"1,2"` → iPhone 6.9" ＋ iPad 13"）
  - ASC 提出フィールドの単一ソースは `docs/app-store-metadata.md`
- **`docs/app-store-metadata.md`**: ASC 実機提出の確定値へ是正
  - 英語アプリ名を却下された `Bubble Pop Game` → 一意な **`Bubble Pop: Relax & Focus`**（App Store 名は全世界一意）
  - 英語サブタイトルの 30 字超過バグ修正（37→25 字）
  - ASC 絵文字拒否・`U+301C`/`U+FF5E` 注意書きを追加
  - キーワードをアプリ名重複除外で最適化
  - 英語プロモを 170 字制限内へ短縮（**絵文字なし**、#42 の除去を維持）
- **`.gitignore`**: `.DS_Store` を追加

## ⚠️ レビュー時の判断ポイント
- `app-store-metadata.md` は origin/main の絵文字除去（#42）を**壊さず**、ASC 提出済みの確定値だけを再適用。作業コピーに残っていた stale な絵文字復活を避けた（regression check 済み: 絵文字は新規の「⚠️ 絵文字拒否」警告ノート内のみ）。
- 英語プロモは作業コピーに 🫧 が混入していたが、絵文字禁止欄なので**除去版**を採用。

## Test plan（docs のみ・ビルド/テスト影響なし）
- [x] `git diff origin/main -- docs/app-store-metadata.md` で絵文字復活リグレッションが無いことを確認
- [x] CLAUDE.md / RELEASE_v1.0.md の追記が既存スタイルに沿うことを確認
- [ ] （マージ前）アプリ名・サブタイトル・キーワードが実際の ASC 入力内容と一致するか目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)