### PR TITLE
perf: テストプラン分割で毎回CIをUnit-onlyに（toward #44）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,13 @@ xcodebuild build -project app/BubblePopGame.xcodeproj -scheme BubblePopGame -con
 xcodebuild clean -project app/BubblePopGame.xcodeproj -scheme BubblePopGame
 ```
 
+### テストプランの使い分け（#44）
+本プロジェクトは共有スキーム + 2 つのテストプランを持つ:
+- **`CI`（デフォルト, UnitTest のみ・並列）**: 毎回の CI / ローカル開発用。`-testPlan` を省略すると `CI` が使われる（Xcode Cloud の標準 Test アクションもこれを拾う）。明示するなら `-testPlan CI`。
+- **`Full`（UnitTest + UITest）**: リリース前 / 手動のみ。`xcodebuild test ... -testPlan Full` で明示指定。
+
+UITest は起動コストが高く flaky なため毎回 CI からは除外している（別枠）。テストプラン実体は `app/CI.xctestplan` / `app/Full.xctestplan`、スキームは `app/BubblePopGame.xcodeproj/xcshareddata/xcschemes/BubblePopGame.xcscheme`。
+
 ### 利用可能シミュレータの確認
 ```bash
 xcrun simctl list devices available | grep -E "iPhone|iPad"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ xcodebuild clean -project app/BubblePopGame.xcodeproj -scheme BubblePopGame
 
 ### テストプランの使い分け（#44）
 本プロジェクトは共有スキーム + 2 つのテストプランを持つ:
-- **`CI`（デフォルト, UnitTest のみ・並列）**: 毎回の CI / ローカル開発用。`-testPlan` を省略すると `CI` が使われる（Xcode Cloud の標準 Test アクションもこれを拾う）。明示するなら `-testPlan CI`。
+- **`CI`（デフォルト, UnitTest のみ・並列）**: 毎回の CI / ローカル開発用。`-testPlan` を省略すると `CI` が使われる（bare `xcodebuild test` で UITest 0 件をローカル実証済み）。明示するなら `-testPlan CI`。⚠️ Xcode Cloud は既存ワークフローがテストターゲットを明示列挙している場合、ASC 側で「CI テストプランを使う」設定変更が 1 回必要（リポからは変更不可）。
 - **`Full`（UnitTest + UITest）**: リリース前 / 手動のみ。`xcodebuild test ... -testPlan Full` で明示指定。
 
 UITest は起動コストが高く flaky なため毎回 CI からは除外している（別枠）。テストプラン実体は `app/CI.xctestplan` / `app/Full.xctestplan`、スキームは `app/BubblePopGame.xcodeproj/xcshareddata/xcschemes/BubblePopGame.xcscheme`。

--- a/app/BubblePopGame.xcodeproj/xcshareddata/xcschemes/BubblePopGame.xcscheme
+++ b/app/BubblePopGame.xcodeproj/xcshareddata/xcschemes/BubblePopGame.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D5DF7FBE2E28B0A4002424F1"
+               BuildableName = "BubblePopGame.app"
+               BlueprintName = "BubblePopGame"
+               ReferencedContainer = "container:BubblePopGame.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:CI.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:Full.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D5DF7FBE2E28B0A4002424F1"
+            BuildableName = "BubblePopGame.app"
+            BlueprintName = "BubblePopGame"
+            ReferencedContainer = "container:BubblePopGame.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D5DF7FBE2E28B0A4002424F1"
+            BuildableName = "BubblePopGame.app"
+            BlueprintName = "BubblePopGame"
+            ReferencedContainer = "container:BubblePopGame.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/app/BubblePopGameUITests/BubblePopGameUITests.swift
+++ b/app/BubblePopGameUITests/BubblePopGameUITests.swift
@@ -45,25 +45,21 @@ final class BubblePopGameUITests: XCTestCase {
     func testGameStart() throws {
         // アプリ起動
         app.launch()
-        
-        // 起動を待機
-        sleep(2)
-        
+
         // チュートリアルスキップ（存在する場合）
         let tutorialSkipButton = app.buttons.containing(NSPredicate(format: "label CONTAINS 'スキップ' OR label CONTAINS 'Skip'")).firstMatch
         if tutorialSkipButton.waitForExistence(timeout: 5.0) {
             tutorialSkipButton.tap()
-            sleep(1)
         }
-        
+
         // メニュー画面が表示されるまで待機
         let gameStartButton = app.buttons["mainMenuGameStart"]
         XCTAssertTrue(gameStartButton.waitForExistence(timeout: 10.0), "ゲーム開始ボタンが表示されない")
         gameStartButton.tap()
-        
-        // ゲーム画面への遷移を待機
-        sleep(3)
-        
+
+        // ゲーム画面への遷移を待機（メニューのスタートボタンが消えることで判定）
+        _ = gameStartButton.waitForNonExistence(timeout: 5.0)
+
         // ゲーム開始が成功したことを確認（基本テスト）
         XCTAssertTrue(true, "ゲーム開始テスト完了")
     }
@@ -71,34 +67,26 @@ final class BubblePopGameUITests: XCTestCase {
     func testGamePauseAndResume() throws {
         // アプリ起動
         app.launch()
-        
-        // 起動を待機
-        sleep(2)
-        
+
         // チュートリアルスキップ（存在する場合）
         let tutorialSkipButton = app.buttons.containing(NSPredicate(format: "label CONTAINS 'スキップ' OR label CONTAINS 'Skip'")).firstMatch
         if tutorialSkipButton.waitForExistence(timeout: 5.0) {
             tutorialSkipButton.tap()
-            sleep(1)
         }
-        
+
         // ゲーム開始
         let gameStartButton = app.buttons["mainMenuGameStart"]
         XCTAssertTrue(gameStartButton.waitForExistence(timeout: 10.0))
         gameStartButton.tap()
-        
-        // ゲームが完全に読み込まれるまで待機
-        sleep(3)
-        
+
         // ポーズボタンをタップ（より柔軟な検索）
         let pauseButton = app.buttons.matching(NSPredicate(format: "label CONTAINS 'ポーズ' OR identifier CONTAINS 'pause'")).firstMatch
         if pauseButton.waitForExistence(timeout: 5.0) {
             pauseButton.tap()
-            
-            // ポーズ画面の表示を確認（短いタイムアウトで簡単にチェック）
-            sleep(1)
-            let pauseExists = app.staticTexts.containing(NSPredicate(format: "label CONTAINS 'ポーズ' OR label CONTAINS 'Pause' OR label CONTAINS '一時停止'")).firstMatch.exists
-            
+
+            // ポーズ画面の表示を確認
+            let pauseExists = app.staticTexts.containing(NSPredicate(format: "label CONTAINS 'ポーズ' OR label CONTAINS 'Pause' OR label CONTAINS '一時停止'")).firstMatch.waitForExistence(timeout: 3.0)
+
             if pauseExists {
                 // 再開ボタンをタップ
                 let resumeButton = app.buttons.containing(NSPredicate(format: "label CONTAINS '再開' OR label CONTAINS 'Resume'")).firstMatch
@@ -107,7 +95,7 @@ final class BubblePopGameUITests: XCTestCase {
                 }
             }
         }
-        
+
         // テスト完了（ポーズ・再開が実行できれば成功とする）
         XCTAssertTrue(true, "ポーズ・再開テスト完了")
     }
@@ -184,20 +172,17 @@ final class BubblePopGameUITests: XCTestCase {
         let gameStartButton = app.buttons["mainMenuGameStart"]
         XCTAssertTrue(gameStartButton.waitForExistence(timeout: 5.0))
         gameStartButton.tap()
-        
-        // ゲーム画面が表示されるまで待機
-        sleep(2)
-        
+
+        // ゲーム画面が表示されるまで待機（メニューを抜けたことで判定）
+        _ = gameStartButton.waitForNonExistence(timeout: 5.0)
+
         // 画面上をタップしてみる（バブルがあるかもしれない場所）
         let gameArea = app.otherElements.firstMatch
         if gameArea.exists {
             gameArea.tap()
-            
-            // 少し待つ
-            sleep(1)
-            
-            // スコアが変更されたかチェック（必ずしもヒットするとは限らないため、エラーにはしない）
-            let scoreExists = app.staticTexts.matching(NSPredicate(format: "label CONTAINS '0' OR label CONTAINS '1' OR label CONTAINS '2'")).firstMatch.exists
+
+            // 少し待つ（スコア表示の出現を待機）
+            let scoreExists = app.staticTexts.matching(NSPredicate(format: "label CONTAINS '0' OR label CONTAINS '1' OR label CONTAINS '2'")).firstMatch.waitForExistence(timeout: 2.0)
             XCTAssertTrue(scoreExists, "スコア表示が見つからない")
         }
     }
@@ -207,15 +192,11 @@ final class BubblePopGameUITests: XCTestCase {
     func testAccessibilityLabels() throws {
         // アプリ起動
         app.launch()
-        
-        // 起動を待機
-        sleep(2)
-        
+
         // チュートリアルスキップ（存在する場合）
         let tutorialSkipButton = app.buttons.containing(NSPredicate(format: "label CONTAINS 'スキップ' OR label CONTAINS 'Skip'")).firstMatch
         if tutorialSkipButton.waitForExistence(timeout: 5.0) {
             tutorialSkipButton.tap()
-            sleep(1)
         }
         
         // メニュー画面の基本的な要素の存在を確認（アクセシビリティ要素として）

--- a/app/BubblePopGameUITests/BubblePopGameUITestsLaunchTests.swift
+++ b/app/BubblePopGameUITests/BubblePopGameUITestsLaunchTests.swift
@@ -57,8 +57,7 @@ final class BubblePopGameUITestsLaunchTests: XCTestCase {
         
         // メモリ使用量の測定（アプリが正常に動作していることの確認）
         // 実際のメモリ測定はXCTMemoryMetricを使用するが、ここでは基本的な動作確認
-        sleep(2) // アプリが安定するまで待機
-        
+
         // アプリがまだ応答することを確認
         XCTAssertTrue(app.buttons["mainMenuGameStart"].exists, "アプリが応答しない")
         XCTAssertTrue(app.buttons["mainMenuSettings"].exists, "アプリが応答しない")
@@ -81,8 +80,7 @@ final class BubblePopGameUITestsLaunchTests: XCTestCase {
         
         // ランドスケープモードへの回転をテスト
         XCUIDevice.shared.orientation = .landscapeLeft
-        sleep(1) // 回転アニメーションを待つ
-        
+
         // 回転後もアプリが正常に動作することを確認
         XCTAssertTrue(menuTitle.exists || menuTitle.waitForExistence(timeout: 3.0), "ランドスケープモードでアプリが正常に表示されない")
         
@@ -93,25 +91,21 @@ final class BubblePopGameUITestsLaunchTests: XCTestCase {
     func testAppStateTransitions() throws {
         let app = XCUIApplication()
         app.launch()
-        
-        // 起動を待機
-        sleep(2)
-        
+
         // チュートリアルスキップ（存在する場合）
         let tutorialSkipButton = app.buttons.containing(NSPredicate(format: "label CONTAINS 'スキップ' OR label CONTAINS 'Skip'")).firstMatch
         if tutorialSkipButton.waitForExistence(timeout: 5.0) {
             tutorialSkipButton.tap()
-            sleep(1)
         }
-        
+
         // メニュー → ゲームの状態遷移をテスト
         let gameStartButton = app.buttons["mainMenuGameStart"]
         XCTAssertTrue(gameStartButton.waitForExistence(timeout: 10.0))
         gameStartButton.tap()
-        
-        // ゲーム画面への遷移を待機
-        sleep(3)
-        
+
+        // ゲーム画面への遷移を待機（メニューを抜けたことで判定）
+        _ = gameStartButton.waitForNonExistence(timeout: 5.0)
+
         // アプリの基本的な状態遷移が成功したことを確認
         XCTAssertTrue(true, "アプリの状態遷移テスト完了")
     }

--- a/app/BubblePopGameUITests/BubblePopGameUITestsLaunchTests.swift
+++ b/app/BubblePopGameUITests/BubblePopGameUITestsLaunchTests.swift
@@ -10,7 +10,7 @@ import XCTest
 final class BubblePopGameUITestsLaunchTests: XCTestCase {
     
     override class var runsForEachTargetApplicationUIConfiguration: Bool {
-        true
+        false
     }
     
     override func setUpWithError() throws {

--- a/app/BubblePopGameUITests/BubblePopGameUITestsLaunchTests.swift
+++ b/app/BubblePopGameUITests/BubblePopGameUITestsLaunchTests.swift
@@ -59,8 +59,8 @@ final class BubblePopGameUITestsLaunchTests: XCTestCase {
         // 実際のメモリ測定はXCTMemoryMetricを使用するが、ここでは基本的な動作確認
 
         // アプリがまだ応答することを確認
-        XCTAssertTrue(app.buttons["mainMenuGameStart"].exists, "アプリが応答しない")
-        XCTAssertTrue(app.buttons["mainMenuSettings"].exists, "アプリが応答しない")
+        XCTAssertTrue(app.buttons["mainMenuGameStart"].waitForExistence(timeout: 3.0), "アプリが応答しない")
+        XCTAssertTrue(app.buttons["mainMenuSettings"].waitForExistence(timeout: 3.0), "アプリが応答しない")
     }
     
     func testOrientationHandling() throws {
@@ -81,8 +81,8 @@ final class BubblePopGameUITestsLaunchTests: XCTestCase {
         // ランドスケープモードへの回転をテスト
         XCUIDevice.shared.orientation = .landscapeLeft
 
-        // 回転後もアプリが正常に動作することを確認
-        XCTAssertTrue(menuTitle.exists || menuTitle.waitForExistence(timeout: 3.0), "ランドスケープモードでアプリが正常に表示されない")
+        // 回転後もアプリが正常に動作することを確認（waitForExistence で回転アニメ完了を待つ）
+        XCTAssertTrue(menuTitle.waitForExistence(timeout: 3.0), "ランドスケープモードでアプリが正常に表示されない")
         
         // 元の向きに戻す
         XCUIDevice.shared.orientation = .portrait

--- a/app/CI.xctestplan
+++ b/app/CI.xctestplan
@@ -1,0 +1,25 @@
+{
+  "configurations" : [
+    {
+      "id" : "C1000000-0000-4000-8000-000000000001",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:BubblePopGame.xcodeproj",
+        "identifier" : "D5DF7FCD2E28B0A6002424F1",
+        "name" : "BubblePopGameTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/app/Full.xctestplan
+++ b/app/Full.xctestplan
@@ -1,0 +1,33 @@
+{
+  "configurations" : [
+    {
+      "id" : "F2000000-0000-4000-8000-000000000002",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:BubblePopGame.xcodeproj",
+        "identifier" : "D5DF7FCD2E28B0A6002424F1",
+        "name" : "BubblePopGameTests"
+      }
+    },
+    {
+      "parallelizable" : false,
+      "target" : {
+        "containerPath" : "container:BubblePopGame.xcodeproj",
+        "identifier" : "D5DF7FD72E28B0A6002424F1",
+        "name" : "BubblePopGameUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/docs/superpowers/plans/2026-06-03-ci-test-time-reduction.md
+++ b/docs/superpowers/plans/2026-06-03-ci-test-time-reduction.md
@@ -1,0 +1,473 @@
+# CI テスト時間短縮 実装計画（Issue #44）
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (推奨, このタスクは xcodebuild の実測フィードバックで反復するため inline 実行が適切) to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 毎回の CI を UnitTest のみ（ビルド+Unit ≈ 100s）に絞り、UITest を別枠化＋無駄削減して、CI テスト時間を約 86% 削減する。
+
+**Architecture:** 共有スキーム + 2 つのテストプラン（`CI`=Unit のみ・デフォルト / `Full`=Unit+UI）をリポに新設し、テストプラン未指定の実行が Unit-only になるようにする。加えて UITest の per-config 反復を無効化し、ハード sleep を要素待機へ置換する。
+
+**Tech Stack:** Xcode 16 / xcodebuild / `.xctestplan`(JSON) / `.xcscheme`(XML) / XCTest(XCUITest)
+
+参考: ターゲット GUID（`app/BubblePopGame.xcodeproj/project.pbxproj` より）
+- app `BubblePopGame`: `D5DF7FBE2E28B0A4002424F1`
+- `BubblePopGameTests`: `D5DF7FCD2E28B0A6002424F1`
+- `BubblePopGameUITests`: `D5DF7FD72E28B0A6002424F1`
+
+ベースライン実測（修正前, iPhone 17 Pro, ローカル）: ビルド 16s / Unit 85s / UITest 617s。
+
+---
+
+## Task 1: テストプラン 2 枚を作成
+
+**Files:**
+- Create: `app/CI.xctestplan`
+- Create: `app/Full.xctestplan`
+
+> 配置場所はパス解決を単純にするため `.xcodeproj` と同じ `app/` 直下（`container:` の `../` を避ける）。spec の `app/TestPlans/` から変更。
+
+- [ ] **Step 1: `app/CI.xctestplan` を作成（Unit のみ・並列）**
+
+```json
+{
+  "configurations" : [
+    {
+      "id" : "C1000000-0000-4000-8000-000000000001",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:BubblePopGame.xcodeproj",
+        "identifier" : "D5DF7FCD2E28B0A6002424F1",
+        "name" : "BubblePopGameTests"
+      }
+    }
+  ],
+  "version" : 1
+}
+```
+
+- [ ] **Step 2: `app/Full.xctestplan` を作成（Unit + UI）**
+
+```json
+{
+  "configurations" : [
+    {
+      "id" : "F2000000-0000-4000-8000-000000000002",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:BubblePopGame.xcodeproj",
+        "identifier" : "D5DF7FCD2E28B0A6002424F1",
+        "name" : "BubblePopGameTests"
+      }
+    },
+    {
+      "parallelizable" : false,
+      "target" : {
+        "containerPath" : "container:BubblePopGame.xcodeproj",
+        "identifier" : "D5DF7FD72E28B0A6002424F1",
+        "name" : "BubblePopGameUITests"
+      }
+    }
+  ],
+  "version" : 1
+}
+```
+
+- [ ] **Step 3: JSON が妥当か検証**
+
+Run: `python3 -m json.tool app/CI.xctestplan >/dev/null && python3 -m json.tool app/Full.xctestplan >/dev/null && echo OK`
+Expected: `OK`（パースエラーなし）
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add app/CI.xctestplan app/Full.xctestplan
+git commit -m "feat: CI / Full テストプランを追加 (#44)"
+```
+
+---
+
+## Task 2: 共有スキームを新設しテストプランを参照
+
+**Files:**
+- Create: `app/BubblePopGame.xcodeproj/xcshareddata/xcschemes/BubblePopGame.xcscheme`
+
+現状 `.xcscheme` は存在せず "BubblePopGame" スキームは自動生成。手書きで共有スキームを作り、TestAction に `CI`(default) と `Full` を登録する。
+
+- [ ] **Step 1: 修正前の状態を確認（RED）**
+
+Run: `xcodebuild -project app/BubblePopGame.xcodeproj -scheme BubblePopGame -showTestPlans 2>&1 | tail -5`
+Expected: テストプランが無い旨のメッセージ（例: `does not use test plans` など）。`CI` / `Full` は**列挙されない**。
+
+- [ ] **Step 2: 共有スキームを作成**
+
+`app/BubblePopGame.xcodeproj/xcshareddata/xcschemes/BubblePopGame.xcscheme`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D5DF7FBE2E28B0A4002424F1"
+               BuildableName = "BubblePopGame.app"
+               BlueprintName = "BubblePopGame"
+               ReferencedContainer = "container:BubblePopGame.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:CI.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:Full.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D5DF7FBE2E28B0A4002424F1"
+            BuildableName = "BubblePopGame.app"
+            BlueprintName = "BubblePopGame"
+            ReferencedContainer = "container:BubblePopGame.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D5DF7FBE2E28B0A4002424F1"
+            BuildableName = "BubblePopGame.app"
+            BlueprintName = "BubblePopGame"
+            ReferencedContainer = "container:BubblePopGame.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>
+```
+
+- [ ] **Step 3: テストプランが認識されるか検証（GREEN）**
+
+Run: `xcodebuild -project app/BubblePopGame.xcodeproj -scheme BubblePopGame -showTestPlans 2>&1 | tail -8`
+Expected: `CI`（デフォルト）と `Full` の 2 つが列挙される。
+（フォーマット不正で失敗した場合は、container パス・GUID・XML 構造を見直し、`-showTestPlans` が両プランを返すまで修正する。）
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add app/BubblePopGame.xcodeproj/xcshareddata/xcschemes/BubblePopGame.xcscheme
+git commit -m "feat: 共有スキームを追加しテストプランを登録 (#44)"
+```
+
+---
+
+## Task 3: CI=Unit のみ / Full=Unit+UI を検証し、新タイムを記録
+
+**Files:** （変更なし。検証のみ）
+
+- [ ] **Step 1: クリーンビルド（計測の前提を揃える）**
+
+Run:
+```bash
+rm -rf build/DerivedData
+xcodebuild build-for-testing -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath build/DerivedData >/tmp/t3-build.log 2>&1
+echo "exit=$?"; tail -1 /tmp/t3-build.log
+```
+Expected: `** TEST BUILD SUCCEEDED **`
+
+- [ ] **Step 2: CI プランは Unit のみ実行されることを検証 + 計測**
+
+Run:
+```bash
+SECONDS=0
+xcodebuild test-without-building -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath build/DerivedData \
+  -testPlan CI >/tmp/t3-ci.log 2>&1
+echo "exit=$? CI elapsed=${SECONDS}s"
+grep -ciE "BubblePopGameUITests" /tmp/t3-ci.log
+```
+Expected: `exit=0`、UITest のヒット数 `0`（UITest が一切走らない）。elapsed は概ね 85s 前後。
+
+- [ ] **Step 3: Full プランは Unit+UI 実行されることを検証**
+
+Run:
+```bash
+xcodebuild test-without-building -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath build/DerivedData \
+  -testPlan Full >/tmp/t3-full.log 2>&1
+echo "exit=$?"
+grep -cE "Test case 'BubblePopGameUITests" /tmp/t3-full.log
+```
+Expected: `exit=0`、UITest のテストケースが 1 件以上実行される。
+
+- [ ] **Step 4: 結果を spec の §5 に追記（before/after の実測）してコミット**
+
+```bash
+git add docs/superpowers/specs/2026-06-03-ci-test-time-reduction-design.md
+git commit -m "docs: CI/Full テストプランの実測結果を記録 (#44)"
+```
+
+---
+
+## Task 4: UITest の per-config 反復を無効化
+
+**Files:**
+- Modify: `app/BubblePopGameUITests/BubblePopGameUITestsLaunchTests.swift:12-14`
+
+`runsForEachTargetApplicationUIConfiguration` が `true` のため `testMemoryUsageAfterLaunch` / `testOrientationHandling` が UI 構成ごとに 6 回以上反復実行されている。`false` にして反復を解消する。
+
+- [ ] **Step 1: override を false に変更**
+
+`BubblePopGameUITestsLaunchTests.swift` の以下を変更:
+
+```swift
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        false
+    }
+```
+
+- [ ] **Step 2: Full プランで反復解消＋時間短縮を検証**
+
+Run:
+```bash
+SECONDS=0
+xcodebuild test-without-building -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath build/DerivedData \
+  -testPlan Full >/tmp/t4-full.log 2>&1
+echo "exit=$? Full elapsed=${SECONDS}s"
+grep -cE "Test case 'BubblePopGameUITestsLaunchTests.testOrientationHandling" /tmp/t4-full.log
+```
+Expected: `exit=0`、`testOrientationHandling` の実行回数が 1（修正前は 6+）。elapsed が Task 3 の Full より大幅に短い。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add app/BubblePopGameUITests/BubblePopGameUITestsLaunchTests.swift
+git commit -m "perf: UITest の per-config 反復を無効化 (#44)"
+```
+
+---
+
+## Task 5: ハード sleep を要素待機へ置換／削除
+
+**Files:**
+- Modify: `app/BubblePopGameUITests/BubblePopGameUITests.swift`
+- Modify: `app/BubblePopGameUITests/BubblePopGameUITestsLaunchTests.swift`
+
+方針: **直後に `waitForExistence` が続く sleep は冗長なので削除**。**末尾でメニュー→ゲーム遷移を待つだけの sleep は `gameStartButton.waitForNonExistence(timeout: 5.0)`（=メニューを抜けたこと）へ置換**。**`.exists` を sleep で待っている箇所は `.waitForExistence(timeout:)` に変えて sleep を削除**。`waitForNonExistence(timeout:)` は Xcode 16 で利用可。
+
+### `BubblePopGameUITests.swift`
+
+- [ ] **Step 1: testGameStart の sleep を整理**
+
+L50 の `sleep(2)`（`// 起動を待機`）を削除。直後の `tutorialSkipButton.waitForExistence(timeout: 5.0)` が起動を待つ。
+L56 の `sleep(1)` を削除。直後に `gameStartButton.waitForExistence(timeout: 10.0)` がある。
+L65 の `sleep(3)`（`// ゲーム画面への遷移を待機`）を次へ置換:
+
+```swift
+        // ゲーム画面への遷移を待機（メニューのスタートボタンが消えることで判定）
+        _ = gameStartButton.waitForNonExistence(timeout: 5.0)
+```
+
+- [ ] **Step 2: testGamePauseAndResume の sleep を整理**
+
+L76 `sleep(2)` 削除（直後に skip の waitForExistence）。
+L82 `sleep(1)` 削除（直後に gameStartButton.waitForExistence）。
+L91 `sleep(3)` 削除（直後に `pauseButton.waitForExistence(timeout: 5.0)` がある）。
+L99-100 の `sleep(1)` + `.exists` を待機に変更:
+
+```swift
+            // ポーズ画面の表示を確認
+            let pauseExists = app.staticTexts.containing(NSPredicate(format: "label CONTAINS 'ポーズ' OR label CONTAINS 'Pause' OR label CONTAINS '一時停止'")).firstMatch.waitForExistence(timeout: 3.0)
+```
+
+- [ ] **Step 3: testBasicGameInteraction の sleep を整理**
+
+L189 `sleep(2)` を遷移待ちへ置換:
+
+```swift
+        // ゲーム画面が表示されるまで待機（メニューを抜けたことで判定）
+        _ = gameStartButton.waitForNonExistence(timeout: 5.0)
+```
+
+L197 `sleep(1)` + L200 の `.exists` を待機へ変更:
+
+```swift
+            // 少し待つ（スコア表示の出現を待機）
+            let scoreExists = app.staticTexts.matching(NSPredicate(format: "label CONTAINS '0' OR label CONTAINS '1' OR label CONTAINS '2'")).firstMatch.waitForExistence(timeout: 2.0)
+```
+
+（上記変更に伴い L197 の `sleep(1)` 行は削除）
+
+- [ ] **Step 4: testAccessibilityLabels の sleep を整理**
+
+L212 `sleep(2)` 削除（直後に skip の waitForExistence）。
+L218 `sleep(1)` 削除（直後に L223 で gameStartButton.waitForExistence）。
+
+### `BubblePopGameUITestsLaunchTests.swift`
+
+- [ ] **Step 5: LaunchTests の sleep を整理**
+
+L60 `sleep(2)`（`// アプリが安定するまで待機`）削除。直前に `menuTitle.waitForExistence(timeout: 10.0)` があり、直後の `mainMenuGameStart` ボタンは存在するはず。
+L84 `sleep(1)`（回転アニメ待ち）削除。直後の `menuTitle.exists || menuTitle.waitForExistence(timeout: 3.0)` が待つ。
+L98 `sleep(2)` 削除（直後に skip の waitForExistence）。
+L104 `sleep(1)` 削除（直後に L109 で gameStartButton.waitForExistence）。
+L113 `sleep(3)` を遷移待ちへ置換:
+
+```swift
+        // ゲーム画面への遷移を待機（メニューを抜けたことで判定）
+        _ = gameStartButton.waitForNonExistence(timeout: 5.0)
+```
+
+- [ ] **Step 6: 残存 sleep がないことを確認**
+
+Run: `grep -rnE "(^| )sleep\(" app/BubblePopGameUITests --include='*.swift'`
+Expected: 出力なし（全 sleep を削除/置換済み）。
+
+- [ ] **Step 7: Full プランが PASS し、さらに高速化したことを検証**
+
+Run:
+```bash
+SECONDS=0
+xcodebuild test-without-building -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath build/DerivedData \
+  -testPlan Full 2>&1 | grep -iE "Test case .* (passed|failed)|TEST (SUCCEEDED|FAILED)" | tail -20
+echo "Full elapsed=${SECONDS}s"
+```
+Expected: `** TEST SUCCEEDED **`、failed のテストケースがない、elapsed が Task 4 よりさらに短い。
+（flaky で落ちる UITest があれば、その箇所の待機タイムアウトを微調整して PASS させる。）
+
+- [ ] **Step 8: コミット**
+
+```bash
+git add app/BubblePopGameUITests/BubblePopGameUITests.swift app/BubblePopGameUITests/BubblePopGameUITestsLaunchTests.swift
+git commit -m "perf: UITest のハード sleep を要素待機へ置換 (#44)"
+```
+
+---
+
+## Task 6: CLAUDE.md にテストプラン運用を追記し、最終確認
+
+**Files:**
+- Modify: `CLAUDE.md`（「ビルドとテスト」セクション）
+
+- [ ] **Step 1: CLAUDE.md にテストプランの使い分けを追記**
+
+「ビルドとテスト」セクションに以下の主旨を追記:
+- 毎回の CI / ローカル開発は `CI` テストプラン（Unit のみ）がデフォルト。`xcodebuild test ...`（プラン未指定）または `-testPlan CI`。
+- UITest を含む全実行は `-testPlan Full` を明示指定（リリース前/手動のみ）。
+- UITest は flaky なため毎回 CI からは外している（#44）。
+
+```markdown
+### テストプランの使い分け（#44）
+- `CI`（デフォルト, Unit のみ）: 毎回の CI・ローカル開発用。`-testPlan CI` か未指定。
+- `Full`（Unit + UITest）: リリース前/手動のみ。`xcodebuild test ... -testPlan Full`。
+- UITest は起動コストが高く flaky なため毎回 CI からは除外（別枠）。
+```
+
+- [ ] **Step 2: 最終確認 — CI プランの実測（ビルド込み総時間）**
+
+Run:
+```bash
+rm -rf build/DerivedData
+SECONDS=0
+xcodebuild test -project app/BubblePopGame.xcodeproj -scheme BubblePopGame \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath build/DerivedData \
+  -testPlan CI 2>&1 | grep -iE "Suite.*(passed|failed)|TEST (SUCCEEDED|FAILED)" | tail -10
+echo "CI total (build+test) elapsed=${SECONDS}s"
+```
+Expected: `** TEST SUCCEEDED **`、総時間が ~100s 前後（ベースライン ~718s から大幅短縮）。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: テストプランの使い分けを CLAUDE.md に追記 (#44)"
+```
+
+---
+
+## 完了後（PR）
+
+- [ ] `git push -u origin feature/issue-44-ci-test-time`
+- [ ] `gh pr create`（base=main）。本文に:
+  - before/after の実測時間表（CI / Full）
+  - 検証チェックリスト（`-showTestPlans` / `-testPlan CI` で UITest 0 件 / `-testPlan Full` PASS / 残存 sleep なし）
+  - ⚠️ **マージ後フォローアップ（ASC, 私からは不可）**: Xcode Cloud のワークフローが既存の暗黙設定の場合、Test アクションが `CI` テストプランを使う（= UITest を含まない）ことを ASC 上で 1 回確認・必要なら設定。
+
+## 自己レビュー結果（spec 対応確認）
+
+- spec §4① 共有スキーム → Task 2 ✅
+- spec §4② テストプラン 2 枚 → Task 1 ✅
+- spec §4③ per-config 無効化 → Task 4 ✅ / sleep 置換 → Task 5 ✅
+- spec §5 CI が拾う仕組み・検証 → Task 3, Task 6 ✅
+- spec §6 ASC フォローアップ → PR セクションに明記 ✅
+- プレースホルダなし・型/メソッド名整合（`waitForNonExistence` / `waitForExistence`）確認済み

--- a/docs/superpowers/specs/2026-06-03-ci-test-time-reduction-design.md
+++ b/docs/superpowers/specs/2026-06-03-ci-test-time-reduction-design.md
@@ -1,0 +1,88 @@
+# CI テスト時間の短縮（Issue #44）設計
+
+- 日付: 2026-06-03
+- 対象 Issue: #44「テスト時間が長すぎる。」（Xcode Cloud の CI/CD が時間かかりすぎる）
+- ブランチ: `feature/issue-44-ci-test-time`（base=main）
+
+## 1. 背景と問題
+
+Xcode Cloud の CI/CD 所要時間が長い。コード読みの推測ではなく、ローカル iPhone 17 Pro シミュレータで工程別に**実測**した内訳:
+
+| 工程 | 時間 | 割合 |
+| --- | --- | --- |
+| クリーンビルド（app + Unit + UI 全ターゲット, `build-for-testing`） | 16s | ~2% |
+| UnitTest 実行（116 funcs, `BubblePopGameTests`） | 85s | ~12% |
+| **UITest 実行（11 funcs, `BubblePopGameUITests`）** | **617s（約10分）** | **~86%** |
+
+計測方法: `xcodebuild build-for-testing`（クリーン）→ `test-without-building -only-testing:<target>` で工程を分離して `SECONDS` 計測。
+
+### 根本原因
+
+1. **UITest が圧倒的なボトルネック（全体の 86%）。** 各 funcs が `app.launch()`（コールド起動）を行い、CI では 1 回あたり数〜十数秒かかる。
+2. **`runsForEachTargetApplicationUIConfiguration = true` による反復実行。** `BubblePopGameUITestsLaunchTests` の `testMemoryUsageAfterLaunch` / `testOrientationHandling` がログ上で**各 6 回以上**実行されており、UI 構成ごとの反復が時間を乗算している（各 ~12s × 6 回 = ~70〜90s/テスト）。
+3. **ハードな固定待機 `sleep(1/2/3)` が多数。** 固定 sleep が積み上がり、かつ flaky の温床になっている。
+4. **共有スキーム・テストプランが両方とも不在。** `app/BubblePopGame.xcodeproj/xcshareddata/xcschemes/` が存在せず、`.xctestplan` も無い。そのため「CI で何を走らせるか」を制御する土台がなく、全テスト（Unit + UI）が無条件に走っている。
+
+> 補足: CLAUDE.md は既に「UITest は起動失敗しやすい」「UnitTest のみに絞ると UITest 起動失敗の影響を避けられる」と複数箇所で警告しており、UITest の CI 上の信頼性は元々低い。本設計はこの既存スタンスと整合する。
+
+## 2. ゴール
+
+毎回の CI（push / PR ごと）を「ビルド + Unit ≈ 100s 前後」に収め、現状（~718s）から**約 86% 削減**する。UITest は CI の毎回実行から外し、回すときも明白な無駄を削って速く・安定させる。
+
+## 3. 確定した方針（ブレスト合意）
+
+- **毎回 CI = UnitTest のみ。** UITest は別枠。
+- **UITest の別枠 = 手動 / ローカル + リリース前のみ。** Nightly や専用 Xcode Cloud ワークフローは作らない（リポ完結・最小）。
+- **UITest 自体の無駄削減も今回のスコープに含める**（per-config 反復の無効化、ハード sleep の置換）。トレードオフとして per-config 反復で得ていた複数 UI 構成のカバレッジは低下することを許容する。
+
+## 4. コンポーネント設計（すべてリポ側で完結）
+
+### ① 共有スキーム新設
+
+`app/BubblePopGame.xcodeproj/xcshareddata/xcschemes/BubblePopGame.xcscheme`
+
+- スキームを共有化し、TestAction に下記 2 つのテストプランを参照させる。
+- **デフォルトテストプランを `CI`** に設定する（`default = "YES"`）。
+- これが全レバーの土台。現状スキームが未共有 = CI 設定が暗黙であるため、まずここを明示化する。
+
+### ② テストプラン 2 枚
+
+配置: `app/TestPlans/`（新規ディレクトリ）
+
+参考: ターゲット GUID（`project.pbxproj` より）
+- app `BubblePopGame`: `D5DF7FBE2E28B0A4002424F1`
+- `BubblePopGameTests`: `D5DF7FCD2E28B0A6002424F1`
+- `BubblePopGameUITests`: `D5DF7FD72E28B0A6002424F1`
+- container: `container:BubblePopGame.xcodeproj`
+
+- **`CI.xctestplan`（デフォルト）**
+  - テストターゲット: `BubblePopGameTests` のみ
+  - `parallelizable = true`（並列実行で 85s のさらなる短縮を狙う）
+- **`Full.xctestplan`**
+  - テストターゲット: `BubblePopGameTests` + `BubblePopGameUITests`
+  - pre-release / 手動でこちらを `-testPlan Full` で明示指定して実行
+
+### ③ UITest の無駄削減
+
+- `BubblePopGameUITestsLaunchTests` の `runsForEachTargetApplicationUIConfiguration` を **`false`** に（同一テストの多重反復を解消。数百秒級の削減）。
+- ハード `sleep(1/2/3)` を、既に併用している `waitForExistence(timeout:)` ベースの待機へ置換（固定待機の積み上げ解消 + flaky 緩和）。安定化に寄与する範囲で段階的に置換する。
+
+## 5. CI が拾う仕組みと検証
+
+- スキームのデフォルトテストプランを `CI` にすれば、テストプラン未指定の `xcodebuild test`（および Xcode Cloud の標準 Test アクション）は **Unit-only** を実行する。
+- **検証コマンド:**
+  - `xcodebuild -project app/BubblePopGame.xcodeproj -scheme BubblePopGame -showTestPlans` → `CI` / `Full` が列挙され、`CI` がデフォルト
+  - `xcodebuild test ... -testPlan CI` → `BubblePopGameTests` のみ実行（UITest が走らない）
+  - `xcodebuild test ... -testPlan Full` → Unit + UITest 実行
+- **before / after の実測時間を記録**し、PR 本文に残す（CLAUDE.md の grep でテスト実体を確認）。
+
+## 6. スコープ外 / マージ後フォローアップ
+
+- ⚠️ **Xcode Cloud ワークフロー設定は ASC 側にあり、リポからは変更できない。** 現在のワークフローが明示的にテストターゲットを列挙している場合、ASC 側で「CI テストプランを使う / UITest ターゲットを外す」設定の確認・更新が**1 回だけ**必要。マージ後タスクとして PR に明記する（#46 の ASC 作業と同じ構図）。
+- UITest の更なる削減（冗長テストの統廃合、Page Object 化など）は本 PR の対象外。
+
+## 7. リスクと対処
+
+- **共有スキーム / xctestplan を手書きする際のフォーマット誤り** → `xcodebuild -showTestPlans` と `-testPlan` 実行で都度検証し、壊れていないことを確認する。
+- **per-config 反復の無効化によるカバレッジ低下** → 合意済みのトレードオフ。orientation テストは単一構成で残るため、最低限の回転検証は維持される。
+- **既存 Xcode Cloud ワークフローがテストプランを自動で拾わない可能性** → §6 のフォローアップで ASC 側確認を必須化することで担保。

--- a/docs/superpowers/specs/2026-06-03-ci-test-time-reduction-design.md
+++ b/docs/superpowers/specs/2026-06-03-ci-test-time-reduction-design.md
@@ -76,6 +76,20 @@ Xcode Cloud の CI/CD 所要時間が長い。コード読みの推測ではな�
   - `xcodebuild test ... -testPlan Full` → Unit + UITest 実行
 - **before / after の実測時間を記録**し、PR 本文に残す（CLAUDE.md の grep でテスト実体を確認）。
 
+### 実測結果（テストプラン導入後）
+
+計測日時: 2026-06-03、環境: iPhone 17 Pro シミュレータ（`test-without-building`、ビルドキャッシュ使用）
+
+| テストプラン | 実行ターゲット | 経過時間 | UITest 実行数 |
+| --- | --- | --- | --- |
+| **CI（デフォルト）** | BubblePopGameTests のみ | **62s** | **0**（確認済み） |
+| **Full** | BubblePopGameTests + BubblePopGameUITests | ~600s 超 | **39 件**（全 passed） |
+
+- CI プランでは UITest が一切走らないことを確認（`grep -cE "BubblePopGameUITests" /tmp/t3-ci.log` = 0）
+- Full プランでは UITest 39 件がすべて passed（フレーキー失敗なし）
+- `xcodebuild -showTestPlans` で CI (default) / Full の 2 プランが列挙されることを確認
+- ベースラインの UnitTest 単体 85s に対して CI プランは **62s**（clean build 後の `build-for-testing` キャッシュ使用のため実際の差分）
+
 ## 6. スコープ外 / マージ後フォローアップ
 
 - ⚠️ **Xcode Cloud ワークフロー設定は ASC 側にあり、リポからは変更できない。** 現在のワークフローが明示的にテストターゲットを列挙している場合、ASC 側で「CI テストプランを使う / UITest ターゲットを外す」設定の確認・更新が**1 回だけ**必要。マージ後タスクとして PR に明記する（#46 の ASC 作業と同じ構図）。

--- a/docs/superpowers/specs/2026-06-03-ci-test-time-reduction-design.md
+++ b/docs/superpowers/specs/2026-06-03-ci-test-time-reduction-design.md
@@ -83,12 +83,13 @@ Xcode Cloud の CI/CD 所要時間が長い。コード読みの推測ではな�
 | テストプラン | 実行ターゲット | 経過時間 | UITest 実行数 |
 | --- | --- | --- | --- |
 | **CI（デフォルト）** | BubblePopGameTests のみ | **62s** | **0**（確認済み） |
-| **Full** | BubblePopGameTests + BubblePopGameUITests | ~600s 超 | **39 件**（全 passed） |
+| **Full** | BubblePopGameTests + BubblePopGameUITests | 未計測（推定 600s 超） | **39 件**（全 passed） |
 
 - CI プランでは UITest が一切走らないことを確認（`grep -cE "BubblePopGameUITests" /tmp/t3-ci.log` = 0）
 - Full プランでは UITest 39 件がすべて passed（フレーキー失敗なし）
 - `xcodebuild -showTestPlans` で CI (default) / Full の 2 プランが列挙されることを確認
 - ベースラインの UnitTest 単体 85s に対して CI プランは **62s**（clean build 後の `build-for-testing` キャッシュ使用のため実際の差分）
+- 注: ベースライン記載「116 funcs」は `func test*` と `@Test` デコレータの重複カウント。実際は全テストが Swift Testing (`import Testing`) で `@Test` = 84 関数が正確な数値（CI プランで 84 件全件 passed、skipped=0 を確認）
 
 ## 6. スコープ外 / マージ後フォローアップ
 

--- a/docs/superpowers/specs/2026-06-03-ci-test-time-reduction-design.md
+++ b/docs/superpowers/specs/2026-06-03-ci-test-time-reduction-design.md
@@ -11,8 +11,8 @@ Xcode Cloud の CI/CD 所要時間が長い。コード読みの推測ではな�
 | 工程 | 時間 | 割合 |
 | --- | --- | --- |
 | クリーンビルド（app + Unit + UI 全ターゲット, `build-for-testing`） | 16s | ~2% |
-| UnitTest 実行（116 funcs, `BubblePopGameTests`） | 85s | ~12% |
-| **UITest 実行（11 funcs, `BubblePopGameUITests`）** | **617s（約10分）** | **~86%** |
+| UnitTest 実行（84 `@Test` funcs, `BubblePopGameTests`） | 85s | ~12% |
+| **UITest 実行（11 funcs / per-config 反復で 39 ケース実行, `BubblePopGameUITests`）** | **617s（約10分）** | **~86%** |
 
 計測方法: `xcodebuild build-for-testing`（クリーン）→ `test-without-building -only-testing:<target>` で工程を分離して `SECONDS` 計測。
 
@@ -47,7 +47,7 @@ Xcode Cloud の CI/CD 所要時間が長い。コード読みの推測ではな�
 
 ### ② テストプラン 2 枚
 
-配置: `app/TestPlans/`（新規ディレクトリ）
+配置: `app/`（`.xcodeproj` と同階層。`container:` の `../` 解決を避けるため。当初案の `app/TestPlans/` から変更）
 
 参考: ターゲット GUID（`project.pbxproj` より）
 - app `BubblePopGame`: `D5DF7FBE2E28B0A4002424F1`
@@ -76,20 +76,29 @@ Xcode Cloud の CI/CD 所要時間が長い。コード読みの推測ではな�
   - `xcodebuild test ... -testPlan Full` → Unit + UITest 実行
 - **before / after の実測時間を記録**し、PR 本文に残す（CLAUDE.md の grep でテスト実体を確認）。
 
-### 実測結果（テストプラン導入後）
+### 実測結果（最終 HEAD での before/after）
 
-計測日時: 2026-06-03、環境: iPhone 17 Pro シミュレータ（`test-without-building`、ビルドキャッシュ使用）
+計測環境: iPhone 17 Pro シミュレータ、ローカル、`SECONDS` 計測。本表は per-config 反復無効化（#44 Task 4）+ ハード sleep 置換（Task 5）まで反映した**最終 HEAD**での値。
 
-| テストプラン | 実行ターゲット | 経過時間 | UITest 実行数 |
+**毎回 CI（push/PR ごと）の総時間**（クリーン後の bare `xcodebuild test`、`-testPlan` 未指定 = デフォルト CI プラン）:
+
+| | 総時間（build + test） | 実行内容 |
+| --- | --- | --- |
+| before（テストプラン導入前・全テスト） | 約 718s | Unit + UITest（UITest は per-config 反復で 39 ケース） |
+| **after（デフォルト CI プラン）** | **105s** | Unit のみ・**UITest 0 件**（bare 実行で `Test case 'BubblePopGameUITests` = 0 を確認） |
+
+→ 毎回 CI を **約 85% 削減**。`-testPlan` 省略の bare `xcodebuild test` で UITest 0 件 = デフォルトの CI プランが拾われることを実証。
+
+**テスト実行のみ**の時間（`test-without-building`、ビルドキャッシュ使用、参考値）:
+
+| テストプラン | 実行ターゲット | 経過時間 | UITest 実行ケース |
 | --- | --- | --- | --- |
-| **CI（デフォルト）** | BubblePopGameTests のみ | **62s** | **0**（確認済み） |
-| **Full** | BubblePopGameTests + BubblePopGameUITests | 未計測（推定 600s 超） | **39 件**（全 passed） |
+| CI（デフォルト） | BubblePopGameTests のみ | 62s | 0 |
+| Full（per-config 無効化 + sleep 置換後） | Unit + UITest | 197s | 11（全 passed） |
 
-- CI プランでは UITest が一切走らないことを確認（`grep -cE "BubblePopGameUITests" /tmp/t3-ci.log` = 0）
-- Full プランでは UITest 39 件がすべて passed（フレーキー失敗なし）
-- `xcodebuild -showTestPlans` で CI (default) / Full の 2 プランが列挙されることを確認
-- ベースラインの UnitTest 単体 85s に対して CI プランは **62s**（clean build 後の `build-for-testing` キャッシュ使用のため実際の差分）
-- 注: ベースライン記載「116 funcs」は `func test*` と `@Test` デコレータの重複カウント。実際は全テストが Swift Testing (`import Testing`) で `@Test` = 84 関数が正確な数値（CI プランで 84 件全件 passed、skipped=0 を確認）
+- Full の UITest は per-config 反復無効化で **39 → 11 ケース**に減少、ハード sleep 置換と合わせ test-only 時間は 617s → **197s**。flaky 失敗なし。
+- `xcodebuild -showTestPlans` で CI (default) / Full の 2 プランが列挙されることを確認。
+- 注: §1 ベースライン表の旧「116 funcs」は `func test*` と `@Test` の重複カウント。全テストが Swift Testing (`import Testing`) で `@Test` = **84** が正（CI プランで 84 件全件 passed、skipped=0）。
 
 ## 6. スコープ外 / マージ後フォローアップ
 


### PR DESCRIPTION
## 概要

毎回の CI を **UnitTest のみ**に絞り、UITest を別枠（リリース前/手動の `Full` プラン）に分離して CI テスト時間を削減する。Issue #44「Xcode Cloud の CI/CD が時間かかりすぎる」への対応。

⚠️ **本 PR の検証はすべてローカル proxy（`xcodebuild`）です。** Issue の本丸は Xcode Cloud であり、その実効果はマージ後に実 Xcode Cloud ビルドで検証するまで未確定です（下記チェックリスト参照）。そのため **`Closes #44` にはしていません（Toward #44）。**

## 変更内容

1. **共有スキーム新設** `app/BubblePopGame.xcodeproj/xcshareddata/xcschemes/BubblePopGame.xcscheme`（従来は自動生成スキーム＝共有なし）
2. **テストプラン2枚**
   - `app/CI.xctestplan`（**デフォルト**, UnitTest のみ）
   - `app/Full.xctestplan`（Unit + UITest、`-testPlan Full` で明示実行）
3. **UITest の無駄削減**
   - `runsForEachTargetApplicationUIConfiguration` を false（per-config 反復で UITest が 39 ケースに増殖していたのを解消）
   - ハード `sleep(1/2/3)` を `waitForExistence`/`waitForNonExistence` へ置換（残存 sleep 0）
4. CLAUDE.md にテストプランの使い分けを追記、設計/計画 docs を追加

## ローカル実測（proxy・iPhone 17 Pro シミュレータ）

| | 総時間 (build+test) | 実行内容 |
|---|---|---|
| before（全テスト） | 約 718s | Unit + UITest(39ケース) |
| **after（bare `xcodebuild test` = 既定 CI）** | **105s** | Unit のみ・**UITest 0 件** |

- 参考（test-only）: Full プランの UITest は per-config 無効化 + sleep 置換で **39→11 ケース / 617s→197s**、flaky 失敗なし
- `-testPlan` 省略の bare 実行で UITest 0 件 = 既定の CI プランが拾われることをローカルで確認

## マージ前に検証済み（ローカル）

- [x] `xcodebuild -showTestPlans` で CI(default)/Full の 2 プランが列挙
- [x] bare `xcodebuild test`（プラン未指定）が UnitTest のみ実行（UITest 0 件）・`** TEST SUCCEEDED **`
- [x] `-testPlan Full` が Unit+UITest を実行し 11/11 passed
- [x] `grep` で残存 `sleep(` ゼロ
- [x] `project.pbxproj` 無変更（file-system synchronized groups + 手書き共有スキーム）

## ⚠️ マージ後に必須の Xcode Cloud 検証（#44 のクローズ条件）

ローカルの 105s はあくまで proxy。以下を実 Xcode Cloud ビルドで確認できて初めて #44 解決とする:

- [ ] マージ後に Xcode Cloud ビルドを 1 本走らせ、**新しい共有スキームで問題なくビルドできる**ことを確認（従来は共有スキームが無かったため、初回ビルドはスキーム/プラン選択の挙動が未知）
- [ ] Test アクションのログで **UITest が走っていない**（Unit のみ）ことを確認
- [ ] wall-clock が実際に短縮されたことを確認
- [ ] もし UITest がまだ走る場合、ASC のワークフロー Test アクションを **CI テストプラン使用**（または UITest ターゲット除外）に 1 回設定変更する（リポからは変更不可）

## 関連
- 設計: `docs/superpowers/specs/2026-06-03-ci-test-time-reduction-design.md`
- 計画: `docs/superpowers/plans/2026-06-03-ci-test-time-reduction.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)