### PR TITLE
docs: v1.1 リリースノート + #44 振り返りを CLAUDE.md 反映

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,10 @@ xcodebuild clean -project app/BubblePopGame.xcodeproj -scheme BubblePopGame
 
 UITest は起動コストが高く flaky なため毎回 CI からは除外している（別枠）。テストプラン実体は `app/CI.xctestplan` / `app/Full.xctestplan`、スキームは `app/BubblePopGame.xcodeproj/xcshareddata/xcschemes/BubblePopGame.xcscheme`。
 
+#### 最適化・調査の進め方（#44 で得た知見）
+- ✅ **「遅い／重い」系の最適化 issue は、コード読みの推測で犯人を決め打たず、まず工程別の時間内訳を実測してから方針を固める**。#44 では advisor が「`CI/CD が遅い ≠ テスト実行が遅い`、clean build が犯人かもしれない」と一旦止め、実測で **UITest 86%(617s) / Unit 12% / build 2%** と確定してから着手した（推測は当たっていたが、ビルドが犯人だった可能性も十分あった）。推測ベースで最適化対象を決めると、見当違いの箇所を磨いて時間を溶かす。
+- ⚠️ **ローカル `xcodebuild` は Xcode Cloud の proxy にすぎない**。CI wall-clock の実効果は**マージ後の実ビルドでしか確定しない**ので、CI 短縮系 PR は `Closes` でなく `Toward` にし、post-merge 検証チェックリストを PR 本文と issue 本体に残す（View 層リテラルがユニットテストをすり抜けるのと同じ「検証の届かない層」テーマの CI 版）。#48 が実例で、実 Xcode Cloud での「UITest 不実行・wall-clock 短縮」確認が #44 のクローズ条件。
+
 ### 利用可能シミュレータの確認
 ```bash
 xcrun simctl list devices available | grep -E "iPhone|iPad"
@@ -124,6 +128,7 @@ app/BubblePopGame/
 ### UI テスト設計
 
 - XCUITest の predicate（例: `CONTAINS '0' OR CONTAINS '1'`）は、意図しない他の UI 要素（時間表示の「60 秒」等）にも偽陽性マッチして検証が空転する。スコア／タイマー等の同種数値要素が画面に共存するときは accessibilityIdentifier で厳密に特定する
+- ⚠️ **`runsForEachTargetApplicationUIConfiguration = true` は UITest を対象 UI 構成数だけ黙って乗算する**。#44 では 11→39 ケースに膨張し数百秒級の無駄が出ていた。実行ログのケース数が定義数より明らかに多い／UITest 数が想定より多いときはこれを疑う。テストプランの設定で false にすると per-config 反復が止まる
 
 ### ローカライズの検証戦略
 

--- a/docs/RELEASE_v1.1.md
+++ b/docs/RELEASE_v1.1.md
@@ -1,0 +1,72 @@
+# RELEASE v1.1 — ITMS リジェクト回避の再提出
+
+- 対象: BubblePopGame v1.1（build 40）の App Store 再提出
+- 作成: 2026-06-05
+- 関連: #46（ASC リジェクト）/ PR #47（バージョン bump）/ #44・PR #48（CI テスト時間短縮）
+
+## 背景（なぜ v1.1 か）
+
+v1.0 が 2026-06-02 に App Store 公開（approved）された後、build 39 を **`1.0` のまま**再提出したため ASC に弾かれた（Issue #46 のスクショが一次証拠）:
+
+- `ITMS-90186` — Invalid Pre-Release Train: 公開済み `1.0` train は新規ビルド提出に対して closed
+- `ITMS-90062` — `CFBundleShortVersionString` は既に承認された `1.0` より高い必要がある
+
+→ MARKETING_VERSION を `1.0` → `1.1` に上げて train を開き直す（PR #47 で対応済み）。
+
+## バージョン
+
+| キー | 値 | 根拠 |
+| --- | --- | --- |
+| `MARKETING_VERSION` (CFBundleShortVersionString) | **1.1** | ASC 承認済み最新 = `1.0`（`git tag v1.0` で確認）。`1.0` train は公開済みで閉じているため `1.1` へ |
+| `CURRENT_PROJECT_VERSION` (CFBundleVersion / build) | **40** | リジェクトメールの最終アップロード build = `39` より上。pbxproj が `36` に lag していたため `40` まで上げて余裕を持たせた |
+
+⚠️ **次回 bump も `release-version-bump-check` skill を Archive 直前に再実行**し、ASC/TestFlight の最高 build + 1 を確認すること（App / Tests / UITests × Debug / Release で計 12 箇所、`replace_all` 推奨）。
+
+## このバージョンの内容（ユーザー向け新機能: なし）
+
+`v1.0`（tag = #43 マージ点）→ HEAD の差分は **すべて内部/CI/docs** で、ユーザー向けの挙動変更はゼロ:
+
+| 変更 | 種別 | PR |
+| --- | --- | --- |
+| CI を UnitTest のみに分離（テストプラン2枚 + 共有スキーム新設） | 内部 / CI | #48（#44） |
+| UITest の per-config 反復無効化 + ハード sleep を要素待機へ置換 | 内部 / テスト品質 | #48（#44） |
+| バージョン番号 v1.1 / build 40 へ bump | リリース機構 | #47（#46） |
+| v1.0 リリース振り返り + ASC ノウハウ docs | docs | #45 |
+| `.DS_Store` を `.gitignore` に追加 | chore | — |
+
+→ よって **本リリースは「ITMS リジェクト回避の再提出」**であり、What's New はメンテナンス系の最小表記とする。
+
+## What's New 下書き
+
+> ja（絵文字OK）:
+> 軽微な内部改善とビルドの安定性向上を行いました。引き続きごゆっくりお楽しみください🫧
+
+> en（**絵文字禁止** — ASC が en の絵文字を「無効な文字」として弾く。plain text）:
+> This update includes minor internal improvements and build stability fixes. Thank you for playing!
+
+## 提出前チェックリスト
+
+### コード側（✅ マージ済み・検証済み）
+- [x] `MARKETING_VERSION = 1.1` / `CURRENT_PROJECT_VERSION = 40`（> リジェクト時 build 39）— `-showBuildSettings` で伝播確認済み（PR #47）
+- [x] Debug ビルド成功（pbxproj 非破損）/ UnitTest 緑（CI テストプラン）
+- [x] 広告/解析/クラッシュ/ネットワーク SDK なし（= App Privacy「データを収集していません」据え置き）
+
+### App Store Connect 側（手動・要対応）
+- [ ] ASC で **v1.1 のバージョンを新規作成**し、What's New を入力（ja は絵文字可 / **en は絵文字 NG**）
+- [ ] スクリーンショット: 既存 v1.0 提出分を流用可（UI 変更なし）。iPhone 6.9" + iPad 13"（`TARGETED_DEVICE_FAMILY = "1,2"` のため両方必須）
+- [ ] App Privacy / 年齢制限 / 説明文・キーワード等は v1.0 から変更なし（`docs/app-store-metadata.md` が単一ソース）
+- [ ] **Xcode で Archive → Distribute**。Archive 直前に build が **≥ 40** であることを `release-version-bump-check` で再確認
+
+### マージ後
+- [ ] `git tag -a v1.1 -m "v1.1 (build 40) ITMS リジェクト回避の再提出" && git push origin v1.1`
+  - ⚠️ **タグは実提出する commit に打つ**。提出前に追加 commit が入るとタグ位置がずれるため、ASC へ Archive/Distribute する commit が確定してから打つこと（v1.0 のときと同じ運用）
+- [ ] 提出が承認されたら本ファイルに「Retrospective」節を追記（`RELEASE_v1.0.md` の慣習に倣う）
+
+---
+
+## クローズ条件（#46）
+
+- [ ] ASC で v1.1 / build 40 が **正常に受理**される（ITMS-90186 / ITMS-90062 が再発しない）
+- [ ] 審査通過後に `git tag v1.1` を push
+
+> #46 は ASC 提出という**外部依存**のため、コード側 bump（PR #47）マージだけではクローズできない。実提出の受理を確認して初めてクローズする。


### PR DESCRIPTION
## 概要

後始末＋次リリース準備の docs-only PR。コード変更なし。

1. **`docs/RELEASE_v1.1.md` 新規作成** — Issue #46（ASC リジェクト）の再提出ノート
2. **CLAUDE.md に #44 セッションの汎用学び3件を追記** — 前回セッションの振り返り候補（`pending-reflection.md`）を反映

## なぜこの PR か

- **#46**: v1.0 公開後に build 39 を `1.0` のまま再提出して `ITMS-90186`/`ITMS-90062` で弾かれた。PR #47 でコード側 bump（v1.1/build40）は済んだが、リリースノート docs が未整備だった。
- **#44**: PR #48（Toward #44）で CI テスト時間短縮はマージ済み。その過程で得た汎用知見を CLAUDE.md に定着させ、次セッションが踏まないようにする。

## RELEASE_v1.1.md の性格

`v1.0` tag（#43 マージ点）→ HEAD の差分は **すべて内部/CI/docs でユーザー向け変更ゼロ**のため、**ITMS 回避の再提出**として What's New はメンテナンス系の最小表記にした（en は絵文字 NG ルール遵守）。提出前チェックリスト + #46 クローズ条件（= ASC 受理の確認、外部依存）を明記。

## CLAUDE.md 追記の3件

- ✅ 最適化 issue は推測でなく**工程別の時間内訳を実測**してから方針（UITest 86% を実測確定した #44 の経験）
- ⚠️ ローカル `xcodebuild` は **Xcode Cloud の proxy にすぎない** → CI 短縮 PR は `Closes` でなく `Toward`、post-merge 検証チェックリストを残す
- ⚠️ `runsForEachTargetApplicationUIConfiguration = true` が **UITest を構成数だけ黙って乗算**（11→39 に膨張）

## Test plan

docs-only のためビルド/テスト影響なし。

- [x] `git diff` で CLAUDE.md 追記が既存節に正しく挿入されていることを確認
- [x] dedup 済み（3件とも CLAUDE.md 未記載を `grep` で確認）
- [ ] マージ前: RELEASE_v1.1.md の What's New 文言レビュー（特に en の絵文字なし）

## 関連

- Toward #46（コード bump は #47 済み、本 PR は docs。**実 ASC 受理でクローズ**）
- #44 の知見定着（#44 自体のクローズ条件は実 Xcode Cloud 検証 = 別途）

🤖 Generated with [Claude Code](https://claude.com/claude-code)