### PR TITLE
chore: fastlane で ASC メタデータ投入を自動化 (toward #46)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,12 @@ fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
 
+# fastlane secrets（公開リポなので絶対にコミットしない。.env.example はテンプレなので追跡する）
+fastlane/.env
+fastlane/*.p8
+fastlane/*.json
+fastlane/metadata/review_information/
+
 # serena mcp
 .serena/cache
 app-store-assets/

--- a/fastlane/.env.example
+++ b/fastlane/.env.example
@@ -1,0 +1,14 @@
+# ASC API Key 認証のテンプレート。
+# これをコピーして fastlane/.env を作り、実値を入れる（.env は gitignore 済み・コミット禁止）。
+#
+#   cp fastlane/.env.example fastlane/.env
+#
+# fastlane は起動時に fastlane/.env を自動ロードするので、この 1 変数だけで
+# download_metadata(CLI) / upload_metadata(lane) / precheck の全部が認証される。
+#
+# 値は App Store Connect で発行する API Key を JSON 化したファイルのパス。
+# JSON の作り方・発行手順は fastlane/SETUP.md を参照。
+# JSON ファイルはリポ外（例: ~/.private_keys/）に置くのが安全。fastlane/ 内に置く場合も
+# *.json / *.p8 は gitignore 済み。
+
+APP_STORE_CONNECT_API_KEY_PATH=

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,12 @@
+# fastlane Appfile — アプリ固有の識別子（公開リポなので秘密情報は置かない）
+#
+# 認証は ASC API Key（推奨）を fastlane/.env から読む（Fastfile 参照）。
+# API Key 方式では apple_id / team_id / itc_team_id は通常不要なので未設定でよい。
+# Apple-ID + App用パスワード方式に切り替える場合のみ下のコメントを有効化する。
+
+app_identifier("com.asapapalab.BubblePopGame")
+
+# --- Apple-ID 方式を使う場合のみ（API Key 方式では不要・公開リポに個人情報を置かない） ---
+# apple_id(ENV["FASTLANE_USER"])      # .env で渡す（ハードコードしない）
+# team_id("XXXXXXXXXX")               # Developer Portal Team ID
+# itc_team_id("XXXXXXXXXX")           # App Store Connect Team ID

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,37 @@
+# fastlane Fastfile — ASC メタデータ投入（バイナリは Xcode Cloud 所有）
+#
+# 設計方針（skill: asc-metadata-delivery）:
+# - バイナリは Xcode Cloud が ASC に upload・処理する。ここでは触らない（skip_binary_upload: true）。
+# - このファイルは「メタデータ（What's New / marketing URL / 説明文 等）だけ」を ASC に stage する。
+# - 審査提出（不可逆）は ASC UI で人間が行う（submit_for_review: false がデフォルト）。
+# - 順序は必ず download → edit → upload → precheck → 人間 submit。
+#   download を先にやらないと live の説明文/キーワードを空で上書きする（fastlane/SETUP.md 参照）。
+#
+# 認証は fastlane 標準の APP_STORE_CONNECT_API_KEY_PATH（API Key JSON のパス）に統一している。
+# fastlane は起動時に fastlane/.env（gitignore 済み）を自動ロードするので、この 1 変数で
+# 「deliver download_metadata（CLI）/ upload_to_app_store（lane）/ precheck」すべてが認証される。
+
+default_platform(:ios)
+
+platform :ios do
+  desc "メタデータを ASC の editable に stage（binary は Xcode Cloud 所有）→ staged コピーを precheck で検証"
+  lane :upload_metadata do
+    # env 未設定なら早期に大声で落とす（暗黙の認証フォールバックで事故らないように）。
+    key_path = ENV.fetch("APP_STORE_CONNECT_API_KEY_PATH")
+
+    # force は付けない: 本番 ASC へ書き込む前に deliver の HTML プレビューを人間が確認する gate を残す。
+    upload_to_app_store(
+      api_key_path: key_path,
+      skip_binary_upload: true,   # バイナリは Xcode Cloud 所有（衝突させない）
+      skip_screenshots: true,     # スクショは v1.0 分を ASC 側で流用（ここでは触らない）
+      submit_for_review: false,   # ステージのみ。提出は ASC UI で人間が意図的に行う
+      precheck_include_in_app_purchases: false,
+      run_precheck_before_submit: false # stage-only では発火しないので、下で明示的に precheck する
+    )
+
+    # precheck は ASC 側の editable（= いま stage したコピー）を検証する。
+    # ローカルファイルは見ない（metadata_path オプションは無い）ので upload の "後" に呼ぶ。
+    # emoji / version bump は precheck の対象外 → upload 前に release-version-bump-check skill で潰す。
+    precheck(api_key_path: key_path)
+  end
+end

--- a/fastlane/SETUP.md
+++ b/fastlane/SETUP.md
@@ -1,0 +1,145 @@
+# fastlane ASC メタデータ投入 セットアップ & 運用手順
+
+バイナリは **Xcode Cloud が所有**したまま、**メタデータ（What's New / marketing URL / 説明文 等）だけ**を fastlane で ASC に投入するための手順。
+（skill: `asc-metadata-delivery` / 検証委譲: `release-version-bump-check`）
+
+---
+
+## ⚠️ 大原則（事故防止）
+
+1. **`upload_metadata` は本番 ASC に書き込む**（`submit_for_review:false` でも editable バージョンに stage される）。「審査に出さない」だけで「ASC に書かない」ではない。
+2. **必ず `download` → `edit` → `upload` → `precheck` → 人間 submit の順**。download を飛ばして upload すると、live の説明文/キーワードを空 or placeholder で**上書き破壊**する。
+3. 投入系コマンドは **creds を持つ人間が手実行**する（CI / 自動化に乗せない）。
+4. **`fastlane/.env`・API Key JSON・`.p8` 秘密鍵はコミット禁止**（`.env` / `*.json` / `*.p8` は gitignore 済み。JSON はリポ外に置くのが安全）。
+
+---
+
+## 1. ASC API Key を発行（初回のみ・所要 5 分）
+
+1. [App Store Connect](https://appstoreconnect.apple.com) → **ユーザーとアクセス** → **統合**（Integrations）タブ → **App Store Connect API**
+2. **「+」**でキーを生成（アクセス権は **App Manager** で十分）
+3. 控える値:
+   - **Key ID**（例 `ABC123DEFG`）
+   - **Issuer ID**（画面上部の UUID）
+   - **`.p8` 秘密鍵ファイル**（**1 回しかダウンロードできない**。安全な場所に保存）
+
+## 2. API Key を JSON ファイル化
+
+fastlane の download(CLI) / upload(lane) / precheck はすべて **API Key JSON ファイル**で認証する（個別フラグ `--api_key_id` 等は CLI に存在しない）。下記の JSON を作る:
+
+```json
+{
+  "key_id": "ABC123DEFG",
+  "issuer_id": "6053b7fe-68a8-4acb-89be-165aa6465141",
+  "key": "-----BEGIN PRIVATE KEY-----\nMIGTAgEAMBMG...（.p8 の中身を改行込みで貼る。実改行でも \\n でも可）...\n-----END PRIVATE KEY-----",
+  "in_house": false
+}
+```
+
+リポ外（例: `~/.private_keys/asc_api_key.json`）に置くのが安全。`fastlane/` 内に置く場合も `*.json` / `*.p8` は gitignore 済み。
+
+> `.p8` の中身を JSON にそのまま貼ればよい（`key` フィールド）。fastlane は実改行・`\n` どちらも受け付ける。
+
+## 3. `.env` を作成
+
+```bash
+cp fastlane/.env.example fastlane/.env
+# fastlane/.env を編集して JSON のパスを入れる:
+#   APP_STORE_CONNECT_API_KEY_PATH=/Users/<you>/.private_keys/asc_api_key.json
+```
+
+fastlane は起動時に `fastlane/.env` を自動ロードするので、**この 1 変数で download(CLI)・upload(lane)・precheck の全部が認証される**。
+
+## 4. 現状の live メタデータを取得（**最初に必ず！**）
+
+```bash
+# リポルートで実行。.env の APP_STORE_CONNECT_API_KEY_PATH を自動で読む。
+# metadata/ に live ASC の全フィールドが txt で落ちてくる（ローカルを上書きするが ASC は変更しない＝読み取り側）。
+fastlane deliver download_metadata
+```
+
+> 認証フラグを明示したい場合のみ: `fastlane deliver download_metadata --api_key_path "$APP_STORE_CONNECT_API_KEY_PATH"`
+> （deliver CLI の API Key 認証は `--api_key_path`（JSON）または `--api_key`（hash）のみ。`--api_key_id` 等は無い。）
+
+これで `fastlane/metadata/<locale>/*.txt` が live の内容で埋まる。**ここを起点に編集する**（placeholder で上書きしない）。
+
+## 5. 変更フィールドだけ編集
+
+`fastlane/metadata/` 配下を編集。download で生成された **`description.txt` / `keywords.txt` 等は触らない**（live を維持）。
+v1.1 で変えるのは **release_notes（What's New）と marketing_url の 2 種だけ**。
+
+```
+metadata/
+├── ja/
+│   ├── release_notes.txt      ← 更新
+│   └── marketing_url.txt      ← 更新
+└── en-US/
+    ├── release_notes.txt      ← 更新（絵文字 NG）
+    └── marketing_url.txt      ← 更新
+```
+
+### v1.1 で投入する内容
+
+**`ja/release_notes.txt`**（まず絵文字あり版。ASC が 🫧 を弾いたら絵文字なし版に差し替え。v1.0 で ja 絵文字が拒否された実績あり）:
+```
+軽微な内部改善とビルドの安定性向上を行いました。引き続きごゆっくりお楽しみください🫧
+```
+絵文字なしフォールバック:
+```
+軽微な内部改善とビルドの安定性向上を行いました。引き続きごゆっくりお楽しみください。
+```
+
+**`en-US/release_notes.txt`**（絵文字禁止・plain text）:
+```
+This update includes minor internal improvements and build stability fixes. Thank you for playing!
+```
+
+**`ja/marketing_url.txt` と `en-US/marketing_url.txt`**（誤った `weightscale-7cdf1.web.app` → サポート URL に是正）:
+```
+https://note.com/es0612swift
+```
+
+## 6. upload 前のローカル検証（precheck が拾わない穴）
+
+- en の `release_notes.txt` に**絵文字が無い**こと（ASC の en は絵文字を silent reject）
+- `MARKETING_VERSION` / build の bump → `release-version-bump-check` skill（v1.1 は `1.1 / 40` 済み）
+
+## 7. 【前提】ASC に v1.1 バージョンが存在すること
+
+`upload_metadata` は ASC の **editable バージョン**にメタデータを stage する。よって **upload 前に v1.1 の editable バージョンが ASC 上に存在している必要がある**:
+- ASC UI で「v1.1 を新規バージョン作成」で先に作る、**または**
+- Xcode Cloud で build 40 が ASC に上がり、その build に紐づく v1.1 バージョンが作られている
+
+存在しない状態で upload すると stage 先が無くエラーになる。
+
+## 8. ASC に stage → 検証
+
+```bash
+fastlane upload_metadata
+```
+
+- `upload_to_app_store`（skip_binary_upload）で metadata を ASC の editable に stage
+- 投入直前に deliver が **HTML プレビュー**を出すので、内容を目視確認してから続行（`force` は付けていない）
+- 続けて `precheck` が staged コピーを検証（placeholder / curse / 到達不能 URL 等）
+
+## 9. 審査提出（人間・ASC UI）
+
+precheck が通ったら、**ASC の Web UI で提出ボタンを押す**（fastlane では自動提出しない）。
+
+提出後の流れは `docs/RELEASE_v1.1.md` の「提出前チェックリスト」「クローズ条件」に従う:
+- Xcode Cloud 配信ビルドの Test ログで **#44 も同時検証**
+- 受理後に `git tag -a v1.1 ... && git push origin v1.1` → #46 / #44 クローズ
+
+---
+
+## トラブルシュート
+
+| 症状 | 対処 |
+| --- | --- |
+| en の What's New が保存できない/弾かれる | 絵文字が混入していないか確認（en は絵文字 NG） |
+| ja の 🫧 が弾かれる | 絵文字なしフォールバック文に差し替え |
+| upload で「version が無い」系エラー | 手順 7。ASC に v1.1 editable バージョンを先に作る |
+| upload で screenshots エラー | `skip_screenshots: true` 済み。スクショは ASC 側で v1.0 分を流用 |
+| live の説明文が消えた | download を飛ばして upload した。download_metadata でやり直し → 再 upload |
+| `ITMS-90186 / 90062` | version bump 漏れ。`release-version-bump-check` skill 参照（v1.1 は対応済み） |
+| 認証エラー | `APP_STORE_CONNECT_API_KEY_PATH` の JSON パス・JSON 中の key_id/issuer_id/key を再確認 |


### PR DESCRIPTION
## 目的

「ASC への申請メタデータ入力を自動化したい」という要望に対し、**バイナリは Xcode Cloud 所有のまま、メタデータ（What's New / marketing URL / 説明文 等）だけ**を fastlane deliver で投入できるよう scaffold する。(skill: `asc-metadata-delivery`)

## 共存の核心

| 所有者 | 対象 |
| --- | --- |
| Xcode Cloud | バイナリ（ipa）の build・upload・処理 |
| fastlane (本PR) | メタデータの stage（`skip_binary_upload: true`） |
| 人間（ASC UI） | 審査提出（`submit_for_review: false` = 自動提出しない） |

## 変更点

- **`fastlane/Fastfile`**: `upload_metadata` lane。`upload_to_app_store`(stage) → `precheck`(staged コピー検証) の順。`force` なしで投入直前の HTML プレビュー gate を残す
- **認証**: fastlane 標準の `APP_STORE_CONNECT_API_KEY_PATH`（API Key JSON）に統一。fastlane が `fastlane/.env` を自動ロードするので **1 変数で download(CLI)/upload(lane)/precheck の全部が認証**される
- **`fastlane/Appfile`**: `app_identifier` のみ（公開リポなので秘密情報・個人情報は置かない）
- **`fastlane/.env.example`**: 認証情報テンプレ（実体 `.env` は gitignore）
- **`fastlane/SETUP.md`**: API Key 発行 → JSON 化 → `download`→`edit`→`upload`→`precheck`→人間submit の手順書 + v1.1 で投入する文言の実値
- **`.gitignore`**: `fastlane/.env` / `*.p8` / `*.json` / `metadata/review_information/` を追加（公開リポの漏洩防止）

## 安全設計（事故防止）

- **download → edit → upload の順を厳守**（download を飛ばすと live の説明文/キーワードを上書き破壊）。SETUP.md で大原則として明記
- `upload` は本番 ASC へ書き込むため **creds を持つ人間が手実行**（CI/自動化に乗せない）
- secrets は全て gitignore（`git check-ignore` で `.env`/`.p8`/`.json`/`review_information` が無視されることを確認済み）

## 検証（正直な範囲）

- ✅ `fastlane lanes` で Fastfile がパースされ `ios upload_metadata` lane が認識される（**parse-verified であって run-verified ではない** — `skip_binary_upload` 等のオプションが実在するかは creds 付き実行時にのみ確定）
- ✅ `fastlane deliver download_metadata --help` / `precheck --help` / `action upload_to_app_store` で **実際の認証フラグ（`--api_key_path` / env `APP_STORE_CONNECT_API_KEY_PATH`）を検証**。CLI に `--api_key_id` 等は存在しないことも確認し、SETUP.md に注記
- ✅ `git check-ignore` で secrets が追跡されないことを確認

## 前提（SETUP.md にも記載）

- `upload_metadata` は ASC の **editable バージョン**に stage するため、upload 前に **v1.1 バージョンが ASC 上に存在**している必要がある（ASC UI で作成 or Xcode Cloud の build 40 が作る）

## Test plan（マージ前手動確認）

- [ ] SETUP.md の手順を読み通し、API Key 発行〜提出までの流れが追えるか
- [ ] （creds 設定後）`fastlane deliver download_metadata` が live メタデータを取得できるか = 実 run-verify
- [ ] download した metadata/ を起点に release_notes / marketing_url を編集 → `fastlane upload_metadata` で HTML プレビューが出るか

> 本 PR は scaffold + 手順書が成果物。実際の ASC 投入（本番書き込み・不可逆提出）はユーザーが creds 付きで実施する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)